### PR TITLE
feat: add license for  files, and fix license check script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ test: install-tools
 check-license:
 	@ sh ./scripts/check-license.sh
 
+add-license:
+	@ sh ./scripts/add-license.sh
+
 build: check
 	@ mkdir -p ./bin
 	@ go build -o ./bin/tatris-meta ./cmd/meta/...

--- a/internal/ingestion/package.go
+++ b/internal/ingestion/package.go
@@ -1,3 +1,5 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
 // Package ingestion organizes codes of the ingestion routine
 package ingestion
 

--- a/internal/meta/package.go
+++ b/internal/meta/package.go
@@ -1,3 +1,5 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
 // Package meta organizes codes for meta service, key component for
 // distribution ability.
 package meta

--- a/internal/query/package.go
+++ b/internal/query/package.go
@@ -1,3 +1,5 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
 // Package query organizes codes on the query routine
 package query
 

--- a/internal/service/package.go
+++ b/internal/service/package.go
@@ -1,3 +1,5 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
 // Package service organizes external APIs
 package service
 

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -2,7 +2,7 @@
 # Check all source files, make sure that they have a license header.
 set -eu
 
-for i in $(git ls-files --exclude-standard | grep "\.go$"); do
+for i in $(find . -type f -not -path '*/\.*' | grep '\.go$'); do
     # first line -> match -> print line -> quit
     matches=$(sed -n "1{/Copyright [0-9]\{4\} Tatris Project Authors. Licensed under Apache-2.0./p;};q;" $i)
     if [ -z "${matches}" ]; then


### PR DESCRIPTION
# Which issue does this PR close?

Closes #43 

# Rationale for this change
 
See the issue.

# What changes are included in this PR?

`check-license.sh`, makefile, and some files that has no license header.

# Are there any user-facing changes?

No, but this will frequently cause the CI failure

# How does this change test
Expected behavior: create a new file without license header, make this project and then it fails.
