### PR TITLE
fix: broken badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # tatris
 [![Build Status](https://github.com/tatris-io/tatris/actions/workflows/build.yml/badge.svg)](https://github.com/tatris-io/tatris/actions/workflows/build.yml)
 ![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/tatris-io/tatris.svg)](https://isitmaintained.com/project/tatris-io/tatris "Percentage of issues still open")
 
 Time-aware storage and search system


### PR DESCRIPTION
## Which issue does this PR close?

No

## Rationale for this change
 
Badge link was wrong. There was no workflow called `build-meta.yml`.

## What changes are included in this PR?

Content of README.md.

## Are there any user-facing changes?

No.

## How does this change test

No. 