### PR TITLE
feat: timeseries-oriented

### DIFF
--- a/internal/common/consts/fields.go
+++ b/internal/common/consts/fields.go
@@ -1,0 +1,12 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+// Package consts defines the global constants of Tatris
+package consts
+
+const (
+	TimestampField = "_timestamp"
+	IDField        = "_id"
+	SourceField    = "_source"
+	IndexField     = "_index"
+	TypeField      = "_type"
+)

--- a/internal/common/consts/path.go
+++ b/internal/common/consts/path.go
@@ -1,0 +1,8 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package consts
+
+const (
+	DefaultDataPath = "/tmp/tatris/_data"
+	DefaultMetaPath = "/tmp/tatris/_meta"
+)

--- a/internal/indexlib/base.go
+++ b/internal/indexlib/base.go
@@ -4,12 +4,6 @@
 package indexlib
 
 const (
-	TimestampField = "@timestamp"
-	IDField        = "_id"
-	SourceField    = "_source"
-	IndexField     = "_index"
-	TypeField      = "_type"
-
 	BlugeIndexLibType = "bluge"
 	DefaultDataPath   = "./_data"
 	FSStorageType     = "fs"

--- a/internal/indexlib/bluge/reader.go
+++ b/internal/indexlib/bluge/reader.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"github.com/blugelabs/bluge"
 	"github.com/blugelabs/bluge/search"
+	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/bluge/config"
 	"log"
@@ -96,15 +97,15 @@ func (b *BlugeReader) generateResponse(dmi search.DocumentMatchIterator) *indexl
 
 		err = next.VisitStoredFields(func(field string, value []byte) bool {
 			switch field {
-			case indexlib.TimestampField:
+			case consts.TimestampField:
 				location, _ := time.LoadLocation("Asia/Shanghai")
 				timestamp, _ = bluge.DecodeDateTime(value)
 				timestamp = timestamp.In(location)
-			case indexlib.IDField:
+			case consts.IDField:
 				id = string(value)
-			case indexlib.IndexField:
+			case consts.IndexField:
 				index = string(value)
-			case indexlib.SourceField:
+			case consts.SourceField:
 				err := json.Unmarshal(value, &source)
 				if err != nil {
 					log.Printf("bluge source unmarshal error: %s", err)

--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blugelabs/bluge"
 	"github.com/blugelabs/bluge/index"
 	segment "github.com/blugelabs/bluge_segment_api"
+	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/bluge/config"
 	"time"
@@ -97,16 +98,24 @@ func (b *BlugeWriter) generateBlugeDoc(docID string, doc map[string]interface{})
 		return nil, err
 	}
 
-	bdoc.AddField(bluge.NewStoredOnlyField(indexlib.IDField, []byte(docID)))
-	bdoc.AddField(bluge.NewStoredOnlyField(indexlib.IndexField, []byte(b.Index)))
-	bdoc.AddField(bluge.NewStoredOnlyField(indexlib.SourceField, source))
-	bdoc.AddField(bluge.NewDateTimeField(indexlib.TimestampField, time.Now()).StoreValue().Sortable().Aggregatable())
+	bdoc.AddField(bluge.NewStoredOnlyField(consts.IDField, []byte(docID)))
+	bdoc.AddField(bluge.NewStoredOnlyField(consts.IndexField, []byte(b.Index)))
+	bdoc.AddField(bluge.NewStoredOnlyField(consts.SourceField, source))
+	bdoc.AddField(bluge.NewDateTimeField(consts.TimestampField, time.Now()).StoreValue().Sortable().Aggregatable())
 
 	return bdoc, nil
 }
 
 func (b *BlugeWriter) addField(bdoc *bluge.Document, key string, value interface{}) {
 	// TODO get index mapping, case field type(text、keyword、bool)
-	field := bluge.NewKeywordField(key, value.(string))
-	bdoc.AddField(field)
+	var bfield *bluge.TermField
+	switch key {
+	case consts.TimestampField:
+		bfield = bluge.NewDateTimeField(key, value.(time.Time))
+	case consts.IDField:
+		bfield = bluge.NewKeywordField(key, value.(string))
+	default:
+		bfield = bluge.NewKeywordField(key, value.(string))
+	}
+	bdoc.AddField(bfield)
 }

--- a/internal/meta/handler/index_handler.go
+++ b/internal/meta/handler/index_handler.go
@@ -17,7 +17,7 @@ func CreateIndexHandler(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"msg": "invalid request"})
 	}
 	idx.Name = idxName
-	if err := metadata.Create(&idx); err != nil {
+	if err := metadata.CreateIndex(&idx); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"msg": err.Error()})
 	} else {
 		c.JSON(http.StatusOK, idx)

--- a/internal/meta/handler/index_handler_test.go
+++ b/internal/meta/handler/index_handler_test.go
@@ -26,10 +26,10 @@ func TestIngestHandler(t *testing.T) {
 		}
 		c.Request = req
 		p := gin.Params{}
-		p = append(p, gin.Param{Key: "index", Value: "index_1"})
+		p = append(p, gin.Param{Key: "index", Value: "storage_product"})
 		c.Params = p
 		c.Request.Header.Set("Content-Type", "application/json;charset=utf-8")
-		c.Request.Body = io.NopCloser(bytes.NewBufferString("{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":1},\"mappings\":{\"properties\":{\"name\":{\"type\":\"keyword\"},\"age\":{\"type\":\"integer\"}}}}"))
+		c.Request.Body = io.NopCloser(bytes.NewBufferString("{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":1},\"mappings\":{\"properties\":{\"name\":{\"type\":\"keyword\"},\"desc\":{\"type\":\"text\"}}}}"))
 		CreateIndexHandler(c)
 		fmt.Println(w)
 		assert.Equal(t, http.StatusOK, w.Code)

--- a/internal/meta/metadata/storage/boltdb/boltdb.go
+++ b/internal/meta/metadata/storage/boltdb/boltdb.go
@@ -6,13 +6,10 @@ package boltdb
 import (
 	"bytes"
 	"errors"
+	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/meta/metadata/storage"
 	"go.etcd.io/bbolt"
 	"time"
-)
-
-const (
-	BoltMetaPath = "/tmp/tatris/_meta.bolt"
 )
 
 type BoltMetaStore struct {
@@ -22,7 +19,7 @@ type BoltMetaStore struct {
 func Open() (storage.MetaStore, error) {
 	// Open the data file.
 	// It will be created if it doesn't exist.
-	db, err := bbolt.Open(BoltMetaPath, 0600, &bbolt.Options{Timeout: 1 * time.Second})
+	db, err := bbolt.Open(consts.DefaultMetaPath+".bolt", 0600, &bbolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #77 

## Rationale for this change
This PR mainly adds constraints on the timestamp field to index creation and document ingestion. 

- When creating an index, `_timestamp` will be automatically added by default, and an error will be returned if the user adds it explicitly.
- When ingesting a document, if the user specifies the value of `_timestamp`, Tatris will use it as the doc time; if the user does not specify it, Tatris will use the current system time as the doc time.

Notice that the query portion has not yet introduced this constraint, because this involves how to split the index into `segments`, we will implement it in a later issue.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Portions of index-creation and doc-ingestion have some constraints added.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users can no longer explicitly add built-in fields such as `_timestamp` and `_id` when creating an index.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Unit test passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
