### PR TITLE
fix: fix indexlib manage

### DIFF
--- a/internal/indexlib/base.go
+++ b/internal/indexlib/base.go
@@ -16,7 +16,7 @@ type BaseConfig struct {
 	IndexLibType string
 }
 
-func NewBaseConfig(config *BaseConfig) *BaseConfig {
+func SetDefaultConfig(config *BaseConfig) *BaseConfig {
 	if config.DataPath == "" {
 		config.DataPath = DefaultDataPath
 	}

--- a/internal/indexlib/bluge/reader.go
+++ b/internal/indexlib/bluge/reader.go
@@ -81,6 +81,24 @@ func (b *BlugeReader) generateQuery(query indexlib.QueryRequest) bluge.Query {
 			q.SetField(query.Field)
 		}
 		blugeQuery = q
+	case *indexlib.BooleanQuery:
+		q := bluge.NewBooleanQuery()
+		if query.Musts != nil {
+			for _, must := range query.Musts {
+				q.AddMust(b.generateQuery(must))
+			}
+		}
+		if query.MustNots != nil {
+			for _, mustNot := range query.MustNots {
+				q.AddMustNot(b.generateQuery(mustNot))
+			}
+		}
+		if query.Shoulds != nil {
+			for _, should := range query.Shoulds {
+				q.AddShould(b.generateQuery(should))
+			}
+		}
+		blugeQuery = q
 	}
 
 	return blugeQuery

--- a/internal/indexlib/manage/reader_test.go
+++ b/internal/indexlib/manage/reader_test.go
@@ -22,13 +22,14 @@ func TestRead(t *testing.T) {
 		t.FailNow()
 	} else {
 		matchQuery := &indexlib.MatchQuery{Match: "tatris", Field: "name"}
-		resp, err := reader.Search(context.Background(), matchQuery, -1)
+		query := &indexlib.BooleanQuery{Musts: []indexlib.QueryRequest{matchQuery}}
+		resp, err := reader.Search(context.Background(), query, -1)
 		if err != nil {
 			t.Log(err)
 		}
 		marshal, _ := json.Marshal(resp)
 		t.Log(string(marshal))
 
-		CloseReader(config)
+		reader.Close()
 	}
 }

--- a/internal/indexlib/manage/writer_test.go
+++ b/internal/indexlib/manage/writer_test.go
@@ -25,6 +25,6 @@ func TestWrite(t *testing.T) {
 		}
 		t.Log("Write success!")
 
-		CloseWriter(config)
+		writer.Close()
 	}
 }

--- a/internal/indexlib/query_request.go
+++ b/internal/indexlib/query_request.go
@@ -6,33 +6,32 @@ type QueryRequest interface {
 	searcher()
 }
 
-type MatchAllQuery struct {
+type baseQuery struct {
+	Boost float64
 }
 
-func (m *MatchAllQuery) searcher() {
+func (m *baseQuery) searcher() {
+}
+
+type MatchAllQuery struct {
+	*baseQuery
 }
 
 type MatchQuery struct {
+	*baseQuery
 	Match string
 	Field string
 }
 
-func (m *MatchQuery) searcher() {
-}
-
 type TermQuery struct {
+	*baseQuery
 	Term  string
 	Field string
 }
 
-func (m *TermQuery) searcher() {
-}
-
 type BooleanQuery struct {
-	Musts    *[]QueryRequest
-	Shoulds  *[]QueryRequest
-	MustNots *[]QueryRequest
-}
-
-func (m *BooleanQuery) searcher() {
+	*baseQuery
+	Musts    []QueryRequest
+	Shoulds  []QueryRequest
+	MustNots []QueryRequest
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
The `Reader` represents a stable snapshot of the index a point in time.
The `Reader/Writer` non-reusable. Delete Reader/Writer pool.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
`internal/indexlib`
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
`internal/indexlib/manage/reader_test.go`
`internal/indexlib/manage/writer_test.go`
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
