### PR TITLE
feat: full text queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/axw/gocov v1.1.0
 	github.com/blugelabs/bluge v0.2.2
 	github.com/blugelabs/bluge_segment_api v0.2.0
+	github.com/blugelabs/query_string v0.3.0
 	github.com/gin-gonic/gin v1.8.2
 	github.com/goccy/go-json v0.10.0
 	github.com/mgechev/revive v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -35,14 +35,18 @@ github.com/blevesearch/snowballstem v0.9.0/go.mod h1:PivSj3JMc8WuaFkTSRDW2SlrulN
 github.com/blevesearch/vellum v1.0.5/go.mod h1:atE0EH3fvk43zzS7t1YNdNC7DbmcC3uz+eMD5xZ2OyQ=
 github.com/blevesearch/vellum v1.0.7 h1:+vn8rfyCRHxKVRgDLeR0FAXej2+6mEb5Q15aQE/XESQ=
 github.com/blevesearch/vellum v1.0.7/go.mod h1:doBZpmRhwTsASB4QdUZANlJvqVAUdUyX0ZK7QJCTeBE=
+github.com/blugelabs/bluge v0.1.7/go.mod h1:5d7LktUkQgvbh5Bmi6tPWtvo4+6uRTm6gAwP+5z6FqQ=
 github.com/blugelabs/bluge v0.2.2 h1:gat8CqE6P6tOgeX30XGLOVNTC26cpM2RWVcreXWtYcM=
 github.com/blugelabs/bluge v0.2.2/go.mod h1:am1LU9jS8dZgWkRzkGLQN3757EgMs3upWrU2fdN9foE=
 github.com/blugelabs/bluge_segment_api v0.2.0 h1:cCX1Y2y8v0LZ7+EEJ6gH7dW6TtVTW4RhG0vp3R+N2Lo=
 github.com/blugelabs/bluge_segment_api v0.2.0/go.mod h1:95XA+ZXfRj/IXADm7gZ+iTcWOJPg5jQTY1EReIzl3LA=
+github.com/blugelabs/ice v0.2.0/go.mod h1:7foiDf4V83FIYYnGh2LOoRWsbNoCqAAMNgKn879Iyu0=
 github.com/blugelabs/ice v1.0.0 h1:um7wf9e6jbkTVCrOyQq3tKK43fBMOvLUYxbj3Qtc4eo=
 github.com/blugelabs/ice v1.0.0/go.mod h1:gNfFPk5zM+yxJROhthxhVQYjpBO9amuxWXJQ2Lo+IbQ=
 github.com/blugelabs/ice/v2 v2.0.1 h1:mzHbntLjk2v7eDRgoXCgzOsPKN1Tenu9Svo6l9cTLS4=
 github.com/blugelabs/ice/v2 v2.0.1/go.mod h1:QxAWSPNwZwsIqS25c3lbIPFQrVvT1sphf5x5DfMLH5M=
+github.com/blugelabs/query_string v0.3.0 h1:/2XMd/3A0lIo33STXMUon4khLcTTybrAcyC0mBLmeA8=
+github.com/blugelabs/query_string v0.3.0/go.mod h1:H0YFWhYAf8/xcv1zoswoUC8kM/fE9L/KEfsgySsnhfs=
 github.com/caio/go-tdigest v3.1.0+incompatible h1:uoVMJ3Q5lXmVLCCqaMGHLBWnbGoN6Lpu7OAUPR60cds=
 github.com/caio/go-tdigest v3.1.0+incompatible/go.mod h1:sHQM/ubZStBUmF1WbB8FAm8q9GjDajLC5T7ydxE3JHI=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -243,6 +247,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/indexlib/query_request.go
+++ b/internal/indexlib/query_request.go
@@ -19,8 +19,26 @@ type MatchAllQuery struct {
 
 type MatchQuery struct {
 	*BaseQuery
-	Match string
-	Field string
+	Match     string
+	Field     string
+	Analyzer  string // STANDARD(default), KEYWORD, SIMPLE, WEB
+	Prefix    int    // Defaults to 0
+	Fuzziness int
+	Operator  string // OR, AND
+}
+
+type MatchPhraseQuery struct {
+	*BaseQuery
+	MatchPhrase string
+	Field       string
+	Analyzer    string
+	Slop        int // Defaults to 0
+}
+
+type QueryString struct {
+	*BaseQuery
+	Query    string
+	Analyzer string
 }
 
 type TermQuery struct {
@@ -31,12 +49,12 @@ type TermQuery struct {
 
 type TermsQuery struct {
 	*BaseQuery
-	Terms map[string]*Terms `json:"terms,omitempty"`
+	Terms map[string]*Terms
 }
 
 type Terms struct {
 	*BaseQuery
-	Fields []string `json:"fields"`
+	Fields []string
 }
 
 type BooleanQuery struct {
@@ -50,12 +68,12 @@ type BooleanQuery struct {
 
 type RangeQuery struct {
 	*BaseQuery
-	Range map[string]*RangeVal `json:"range,omitempty"`
+	Range map[string]*RangeVal
 }
 
 type RangeVal struct {
-	GT  interface{} `json:"gt,omitempty"`  // null, float64
-	GTE interface{} `json:"gte,omitempty"` // null, float64
-	LT  interface{} `json:"lt,omitempty"`  // null, float64
-	LTE interface{} `json:"lte,omitempty"` // null, float64
+	GT  interface{}
+	GTE interface{}
+	LT  interface{}
+	LTE interface{}
 }

--- a/internal/protocol/query_request.go
+++ b/internal/protocol/query_request.go
@@ -17,6 +17,8 @@ type Query struct {
 	Match *Match `json:"match,omitempty"`
 	// {"match_phrase": {"field": "value"}}
 	MatchPhrase *MatchPhrase `json:"match_phrase,omitempty"`
+	// {"query_string": {"query": "field:value"}}
+	QueryString *QueryString `json:"query_string,omitempty"`
 	// {"ids": {"values": ["id1", "id2"]}}
 	Ids *Ids `json:"ids,omitempty"`
 	// {"term": {"field": "value"}}
@@ -34,6 +36,8 @@ type MatchAll struct{}
 type Match map[string]interface{}
 
 type MatchPhrase map[string]interface{}
+
+type QueryString map[string]interface{}
 
 type Ids struct {
 	Values []string `json:"values"`

--- a/internal/query/handler/query_handler_test.go
+++ b/internal/query/handler/query_handler_test.go
@@ -29,7 +29,8 @@ func TestQueryHandler(t *testing.T) {
 		p = append(p, gin.Param{Key: "index", Value: "storage_product"})
 		c.Params = p
 		c.Request.Header.Set("Content-Type", "application/json;charset=utf-8")
-		query := "{\"query\":{\"bool\":{\"must\":[{\"match_all\":{}}],\"must_not\":[{\"term\":{\"name\":\"mysql\"}}]}}}"
+		query := "{\"size\":20,\"query\":{\"bool\":{\"must\":[{\"match\":{\"name\":{\"query\":\"tatris\",\"prefix_length\":5,\"fuzziness\":1}}}," +
+			"{\"query_string\":{\"query\":\"name:tatris\"}}],\"must_not\":[{\"term\":{\"name\":{\"value\":\"mysql\"}}}]}}}"
 		c.Request.Body = io.NopCloser(bytes.NewBufferString(query))
 		QueryHandler(c)
 		fmt.Println(w)

--- a/internal/query/query_doc.go
+++ b/internal/query/query_doc.go
@@ -47,130 +47,217 @@ func transform(query protocol.Query) (indexlib.QueryRequest, error) {
 	if query.MatchAll != nil {
 		return &indexlib.MatchAllQuery{}, nil
 	} else if query.Match != nil {
-		matches := *query.Match
-		if len(matches) != 1 {
-			return nil, errors.New("invalid match query")
-		}
-		matchQ := indexlib.MatchQuery{}
-		for k, v := range matches {
-			matchQ.Field = k
-			matchQ.Match = v.(string)
-		}
-		return &matchQ, nil
+		return transformMatch(query)
+	} else if query.MatchPhrase != nil {
+		return transformMatchPhrase(query)
+	} else if query.QueryString != nil {
+		return transformQueryString(query)
 	} else if query.Term != nil {
-		term := *query.Term
-		if len(term) <= 0 {
-			return &indexlib.TermQuery{}, nil
-		}
-		termQ := indexlib.TermQuery{}
-		for k, v := range term {
-			termQ.Field = k
-			termQ.Term = v.(string)
-			//termQ.Term = v.(map[string]interface{})["value"].(string)
-		}
-		return &termQ, nil
+		return transformTerm(query)
 	} else if query.Ids != nil {
-		ids := *query.Ids
-		if len(ids.Values) <= 0 {
-			return &indexlib.Terms{}, nil
-		}
-		termsQ := indexlib.Terms{}
-		termsQ.Fields = append(termsQ.Fields, ids.Values...)
-		return &termsQ, nil
+		return transformIds(query)
 	} else if query.Terms != nil {
-		terms := *query.Terms
-		if len(terms) <= 0 {
-			return &indexlib.TermsQuery{}, nil
-		}
-		field := ""
-		values := []string{}
-		termsQ := indexlib.TermsQuery{}
-		for k, v := range terms {
-			field = k
-			for _, vv := range v {
-				switch vv := vv.(type) {
-				case string:
-					values = append(values, vv)
-				default:
-					return nil, errors.New("unsupported terms value type")
-				}
-			}
-			termsQ.Terms[field] = &indexlib.Terms{
-				Fields: values,
-			}
-		}
-		return &termsQ, nil
+		return transformTerms(query)
 	} else if query.Range != nil {
-		rangeQuery := *query.Range
-		if len(rangeQuery) <= 0 {
-			return &indexlib.RangeQuery{}, nil
-		}
-
-		var rangeQ *indexlib.RangeQuery
-		for k, v := range rangeQuery {
-			rangeQ = &indexlib.RangeQuery{Range: map[string]*indexlib.RangeVal{
-				k: {
-					GT:  v.Gt,
-					GTE: v.Gte,
-					LT:  v.Lt,
-					LTE: v.Lte,
-				},
-			}}
-		}
-		return rangeQ, nil
+		return transformRange(query)
 	} else if query.Bool != nil {
-		q := &indexlib.BooleanQuery{}
-
-		if query.Bool.Must != nil {
-			q.Musts = make([]indexlib.QueryRequest, 0, len(query.Bool.Must))
-			for _, must := range query.Bool.Must {
-				queryRequest, err := transform(*must)
-				if err != nil {
-					return nil, errors.New("bool query must transform error")
-				}
-				q.Musts = append(q.Musts, queryRequest)
-			}
-		}
-		if query.Bool.MustNot != nil {
-			q.MustNots = make([]indexlib.QueryRequest, 0, len(query.Bool.MustNot))
-			for _, mustNot := range query.Bool.MustNot {
-				queryRequest, err := transform(*mustNot)
-				if err != nil {
-					return nil, errors.New("bool query mustNot transform error")
-				}
-				q.MustNots = append(q.MustNots, queryRequest)
-			}
-		}
-		if query.Bool.Should != nil {
-			q.Shoulds = make([]indexlib.QueryRequest, 0, len(query.Bool.Should))
-			for _, should := range query.Bool.Should {
-				queryRequest, err := transform(*should)
-				if err != nil {
-					return nil, errors.New("bool query should transform error")
-				}
-				q.Shoulds = append(q.Shoulds, queryRequest)
-			}
-		}
-		if query.Bool.Filter != nil {
-			q.Filters = make([]indexlib.QueryRequest, 0, len(query.Bool.Filter))
-			for _, filter := range query.Bool.Filter {
-				queryRequest, err := transform(*filter)
-				if err != nil {
-					return nil, errors.New("bool query filter transform error")
-				}
-				q.Filters = append(q.Filters, queryRequest)
-			}
-		}
-		if query.Bool.MinimumShouldMatch != "" {
-			minShould, err := strconv.Atoi(query.Bool.MinimumShouldMatch)
-			if err != nil {
-				return nil, errors.New("bool query minimumShouldMatch transform error")
-			}
-			q.MinShould = minShould
-		}
-		return q, nil
+		return transformBool(query)
 	} else {
 		// TODO: need to be supported
 		return nil, errors.New("need to be supported")
 	}
+}
+
+func transformMatch(query protocol.Query) (indexlib.QueryRequest, error) {
+	matches := *query.Match
+	if len(matches) <= 0 {
+		return nil, errors.New("invalid match query")
+	}
+	matchQ := indexlib.MatchQuery{}
+	for k, v := range matches {
+		matchQ.Field = k
+		switch v := v.(type) {
+		case string:
+			matchQ.Match = v
+		case map[string]interface{}:
+			matchQ.Match = v["query"].(string)
+			if operator, ok := v["operator"]; ok {
+				matchQ.Operator = operator.(string)
+			}
+			if fuzziness, ok := v["fuzziness"]; ok {
+				matchQ.Fuzziness = int(fuzziness.(float64))
+			}
+			if prefix, ok := v["prefix_length"]; ok {
+				matchQ.Prefix = int(prefix.(float64))
+			}
+			if analyzer, ok := v["analyzer"]; ok {
+				matchQ.Analyzer = analyzer.(string)
+			}
+		}
+	}
+	return &matchQ, nil
+}
+
+func transformMatchPhrase(query protocol.Query) (indexlib.QueryRequest, error) {
+	matches := *query.MatchPhrase
+	if len(matches) <= 0 {
+		return nil, errors.New("invalid match phrase query")
+	}
+	matchQ := indexlib.MatchPhraseQuery{}
+	for k, v := range matches {
+		matchQ.Field = k
+		switch v := v.(type) {
+		case string:
+			matchQ.MatchPhrase = v
+		case map[string]interface{}:
+			matchQ.MatchPhrase = v["query"].(string)
+			if slop, ok := v["slop"]; ok {
+				matchQ.Slop = int(slop.(float64))
+			}
+			if analyzer, ok := v["analyzer"]; ok {
+				matchQ.Analyzer = analyzer.(string)
+			}
+		}
+	}
+	return &matchQ, nil
+}
+
+func transformQueryString(query protocol.Query) (indexlib.QueryRequest, error) {
+	querys := *query.QueryString
+	if len(querys) <= 0 {
+		return nil, errors.New("invalid query string query")
+	}
+	queryStr := indexlib.QueryString{}
+	queryStr.Query = querys["query"].(string)
+	if analyzer, ok := querys["analyzer"]; ok {
+		queryStr.Analyzer = analyzer.(string)
+	}
+
+	return &queryStr, nil
+}
+
+func transformTerm(query protocol.Query) (indexlib.QueryRequest, error) {
+	term := *query.Term
+	if len(term) <= 0 {
+		return &indexlib.TermQuery{}, nil
+	}
+	termQ := indexlib.TermQuery{}
+	for k, v := range term {
+		termQ.Field = k
+		switch v := v.(type) {
+		case string:
+			termQ.Term = v
+		case map[string]interface{}:
+			termQ.Term = v["value"].(string)
+		}
+	}
+	return &termQ, nil
+}
+
+func transformIds(query protocol.Query) (indexlib.QueryRequest, error) {
+	ids := *query.Ids
+	if len(ids.Values) <= 0 {
+		return &indexlib.Terms{}, nil
+	}
+	termsQ := indexlib.Terms{}
+	termsQ.Fields = append(termsQ.Fields, ids.Values...)
+	return &termsQ, nil
+}
+
+func transformTerms(query protocol.Query) (indexlib.QueryRequest, error) {
+	terms := *query.Terms
+	if len(terms) <= 0 {
+		return &indexlib.TermsQuery{}, nil
+	}
+	field := ""
+	values := []string{}
+	termsQ := indexlib.TermsQuery{}
+	for k, v := range terms {
+		field = k
+		for _, vv := range v {
+			switch vv := vv.(type) {
+			case string:
+				values = append(values, vv)
+			default:
+				return nil, errors.New("unsupported terms value type")
+			}
+		}
+		termsQ.Terms[field] = &indexlib.Terms{
+			Fields: values,
+		}
+	}
+	return &termsQ, nil
+}
+
+func transformRange(query protocol.Query) (indexlib.QueryRequest, error) {
+	rangeQuery := *query.Range
+	if len(rangeQuery) <= 0 {
+		return &indexlib.RangeQuery{}, nil
+	}
+
+	var rangeQ *indexlib.RangeQuery
+	for k, v := range rangeQuery {
+		rangeQ = &indexlib.RangeQuery{Range: map[string]*indexlib.RangeVal{
+			k: {
+				GT:  v.Gt,
+				GTE: v.Gte,
+				LT:  v.Lt,
+				LTE: v.Lte,
+			},
+		}}
+	}
+	return rangeQ, nil
+}
+
+func transformBool(query protocol.Query) (indexlib.QueryRequest, error) {
+	q := &indexlib.BooleanQuery{}
+
+	if query.Bool.Must != nil {
+		q.Musts = make([]indexlib.QueryRequest, 0, len(query.Bool.Must))
+		for _, must := range query.Bool.Must {
+			queryRequest, err := transform(*must)
+			if err != nil {
+				return nil, errors.New("bool query must transform error")
+			}
+			q.Musts = append(q.Musts, queryRequest)
+		}
+	}
+	if query.Bool.MustNot != nil {
+		q.MustNots = make([]indexlib.QueryRequest, 0, len(query.Bool.MustNot))
+		for _, mustNot := range query.Bool.MustNot {
+			queryRequest, err := transform(*mustNot)
+			if err != nil {
+				return nil, errors.New("bool query mustNot transform error")
+			}
+			q.MustNots = append(q.MustNots, queryRequest)
+		}
+	}
+	if query.Bool.Should != nil {
+		q.Shoulds = make([]indexlib.QueryRequest, 0, len(query.Bool.Should))
+		for _, should := range query.Bool.Should {
+			queryRequest, err := transform(*should)
+			if err != nil {
+				return nil, errors.New("bool query should transform error")
+			}
+			q.Shoulds = append(q.Shoulds, queryRequest)
+		}
+	}
+	if query.Bool.Filter != nil {
+		q.Filters = make([]indexlib.QueryRequest, 0, len(query.Bool.Filter))
+		for _, filter := range query.Bool.Filter {
+			queryRequest, err := transform(*filter)
+			if err != nil {
+				return nil, errors.New("bool query filter transform error")
+			}
+			q.Filters = append(q.Filters, queryRequest)
+		}
+	}
+	if query.Bool.MinimumShouldMatch != "" {
+		minShould, err := strconv.Atoi(query.Bool.MinimumShouldMatch)
+		if err != nil {
+			return nil, errors.New("bool query minimumShouldMatch transform error")
+		}
+		q.MinShould = minShould
+	}
+	return q, nil
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #67

## Rationale for this change
 The full text queries enable you to search analyzed text fields. The query string is processed using the same analyzer that was applied to the field during indexing.
The following most important full text queries should probably be implemented first.
 - match query
 - match_phrase query
 - query_string query
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Support match、match_phrase、query_string query
`internal/query`
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
`internal/query/handler/query_handler_test.go`
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
