### PR TITLE
chore: add golines to format excessively long lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ check: install-tools
 	@ echo "$(PACKAGE_DIRECTORIES)"
 	@ gofmt -s -l -w $(PACKAGE_DIRECTORIES)
 	@ echo "golines ..."
-	@ golines --max-len=100 --shorten-comments -w internal cmd
+	@ golines --max-len=100 --shorten-comments -w internal cmd test
 	@ echo "golangci-lint ..."
 	@ golangci-lint run -c golangci-lint.yml $(PACKAGE_DIRECTORIES_WITHOUT_TOOLSET)
 	@ echo "revive ..."

--- a/internal/common/utils/IDUtils.go
+++ b/internal/common/utils/IDUtils.go
@@ -6,6 +6,7 @@ package utils
 import (
 	"crypto/rand"
 	"fmt"
+
 	"github.com/tatris-io/tatris/internal/common/log/logger"
 )
 

--- a/internal/core/core_test/index_test.go
+++ b/internal/core/core_test/index_test.go
@@ -3,14 +3,15 @@
 package core_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/meta/metadata"
 	"github.com/tatris-io/tatris/internal/protocol"
 	"github.com/tatris-io/tatris/internal/query"
 	"github.com/tatris-io/tatris/test/ut/prepare"
-	"testing"
-	"time"
 )
 
 func TestIndex(t *testing.T) {
@@ -37,7 +38,13 @@ func TestIndex(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, len(docs)/10, len(readers))
 
-		hits, err := query.SearchDocs(protocol.QueryRequest{Index: index.Name, Query: protocol.Query{Term: protocol.Term{"name": "elasticsearch"}}, Size: 20})
+		hits, err := query.SearchDocs(
+			protocol.QueryRequest{
+				Index: index.Name,
+				Query: protocol.Query{Term: protocol.Term{"name": "elasticsearch"}},
+				Size:  20,
+			},
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(hits.Hits))
 	})

--- a/internal/core/segment.go
+++ b/internal/core/segment.go
@@ -4,11 +4,12 @@ package core
 
 import (
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/manage"
-	"sync"
-	"time"
 )
 
 // Segment is a physical split of the index under a shard

--- a/internal/core/shard.go
+++ b/internal/core/shard.go
@@ -3,9 +3,10 @@
 package core
 
 import (
+	"sync"
+
 	"github.com/tatris-io/tatris/internal/common/log/logger"
 	"go.uber.org/zap"
-	"sync"
 )
 
 // Shard is a logical split of the index

--- a/internal/indexlib/bluge/range_parser.go
+++ b/internal/indexlib/bluge/range_parser.go
@@ -4,11 +4,12 @@ package bluge
 
 import (
 	"fmt"
+	"math"
+	"strconv"
+
 	"github.com/blugelabs/bluge"
 	"github.com/tatris-io/tatris/internal/common/errors"
 	"github.com/tatris-io/tatris/internal/indexlib"
-	"math"
-	"strconv"
 )
 
 func RangeQueryParse(rangeQuery *indexlib.RangeQuery) (bluge.Query, error) {

--- a/internal/indexlib/bluge/reader.go
+++ b/internal/indexlib/bluge/reader.go
@@ -6,6 +6,10 @@ package bluge
 import (
 	"context"
 	"encoding/json"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/blugelabs/bluge"
 	"github.com/blugelabs/bluge/analysis"
 	"github.com/blugelabs/bluge/analysis/analyzer"
@@ -14,9 +18,6 @@ import (
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/bluge/config"
-	"log"
-	"strings"
-	"time"
 )
 
 type BlugeReader struct {
@@ -47,7 +48,11 @@ func (b *BlugeReader) OpenReader() error {
 	return nil
 }
 
-func (b *BlugeReader) Search(ctx context.Context, query indexlib.QueryRequest, limit int) (*indexlib.QueryResponse, error) {
+func (b *BlugeReader) Search(
+	ctx context.Context,
+	query indexlib.QueryRequest,
+	limit int,
+) (*indexlib.QueryResponse, error) {
 	blugeQuery, err := b.generateQuery(query)
 	if err != nil {
 		return nil, err
@@ -210,7 +215,9 @@ func (b *BlugeReader) generateMatchQuery(query *indexlib.MatchQuery) (bluge.Quer
 	return q, nil
 }
 
-func (b *BlugeReader) generateMatchPhraseQuery(query *indexlib.MatchPhraseQuery) (bluge.Query, error) {
+func (b *BlugeReader) generateMatchPhraseQuery(
+	query *indexlib.MatchPhraseQuery,
+) (bluge.Query, error) {
 	q := bluge.NewMatchPhraseQuery(query.MatchPhrase)
 	if query.Field != "" {
 		q.SetField(query.Field)

--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -4,15 +4,16 @@ package bluge
 
 import (
 	"encoding/json"
+	"log"
+	"strconv"
+	"time"
+
 	"github.com/blugelabs/bluge"
 	"github.com/blugelabs/bluge/index"
 	segment "github.com/blugelabs/bluge_segment_api"
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/bluge/config"
-	"log"
-	"strconv"
-	"time"
 )
 
 type BlugeWriter struct {
@@ -81,7 +82,10 @@ func (b *BlugeWriter) Close() {
 	}
 }
 
-func (b *BlugeWriter) generateBlugeDoc(docID string, doc map[string]interface{}) (segment.Document, error) {
+func (b *BlugeWriter) generateBlugeDoc(
+	docID string,
+	doc map[string]interface{},
+) (segment.Document, error) {
 	bdoc := bluge.NewDocument(docID)
 	for key, value := range doc {
 		if value == nil {
@@ -106,7 +110,12 @@ func (b *BlugeWriter) generateBlugeDoc(docID string, doc map[string]interface{})
 	bdoc.AddField(bluge.NewStoredOnlyField(consts.IDField, []byte(docID)))
 	bdoc.AddField(bluge.NewStoredOnlyField(consts.IndexField, []byte(b.Index)))
 	bdoc.AddField(bluge.NewStoredOnlyField(consts.SourceField, source))
-	bdoc.AddField(bluge.NewDateTimeField(consts.TimestampField, time.Now()).StoreValue().Sortable().Aggregatable())
+	bdoc.AddField(
+		bluge.NewDateTimeField(consts.TimestampField, time.Now()).
+			StoreValue().
+			Sortable().
+			Aggregatable(),
+	)
 
 	return bdoc, nil
 }

--- a/internal/indexlib/indexlib_test/indexlib_test.go
+++ b/internal/indexlib/indexlib_test/indexlib_test.go
@@ -5,6 +5,10 @@ package indexlib_test
 import (
 	"context"
 	"encoding/json"
+	"path"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/log/logger"
@@ -12,9 +16,6 @@ import (
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/manage"
 	"github.com/tatris-io/tatris/test/ut/prepare"
-	"path"
-	"testing"
-	"time"
 )
 
 func TestIndexLib(t *testing.T) {

--- a/internal/indexlib/manage/manage.go
+++ b/internal/indexlib/manage/manage.go
@@ -5,14 +5,16 @@ package manage
 
 import (
 	"errors"
+	"log"
+
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/bluge"
-	"log"
 )
 
 // GetReader The Reader represents a stable snapshot of the index a point in time.
-// This means that changes made to the index after the reader is obtained never affect the results returned by this reader.
-// This also means that this Reader is holding onto resources and MUST be closed when it is no longer needed.
+// This means that changes made to the index after the reader is obtained never affect the results
+// returned by this reader. This also means that this Reader is holding onto resources and MUST be
+// closed when it is no longer needed.
 func GetReader(config *indexlib.BaseConfig) (indexlib.Reader, error) {
 	if config.Index == "" {
 		return nil, errors.New("no index specified")
@@ -34,8 +36,9 @@ func GetReader(config *indexlib.BaseConfig) (indexlib.Reader, error) {
 	}
 }
 
-// GetWriter Writer’s hold an exclusive-lock on their underlying directory which prevents other processes from opening a writer while this one is still open.
-// This does not affect Readers that are already open, and it does not prevent new Readers from being opened,
+// GetWriter Writer’s hold an exclusive-lock on their underlying directory which prevents other
+// processes from opening a writer while this one is still open. This does not affect Readers that
+// are already open, and it does not prevent new Readers from being opened,
 // but it does mean care care should be taken to close the Writer when you done.
 func GetWriter(config *indexlib.BaseConfig) (indexlib.Writer, error) {
 	if config.Index == "" {

--- a/internal/ingestion/handler/ingest_handler.go
+++ b/internal/ingestion/handler/ingest_handler.go
@@ -5,17 +5,21 @@ package handler
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/tatris-io/tatris/internal/ingestion"
 	"github.com/tatris-io/tatris/internal/meta/metadata"
 	"github.com/tatris-io/tatris/internal/protocol"
-	"net/http"
 )
 
 func IngestHandler(c *gin.Context) {
 	indexName := c.Param("index")
 	if index, err := metadata.GetIndex(indexName); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"msg": "get index fail: " + indexName + ", " + err.Error()})
+		c.JSON(
+			http.StatusInternalServerError,
+			gin.H{"msg": "get index fail: " + indexName + ", " + err.Error()},
+		)
 	} else if index == nil {
 		c.JSON(http.StatusNotFound, gin.H{"msg": fmt.Sprintf("index not found: %s", indexName)})
 	} else {

--- a/internal/ingestion/handler/ingest_handler_test.go
+++ b/internal/ingestion/handler/ingest_handler_test.go
@@ -5,16 +5,17 @@ package handler
 import (
 	"bytes"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
-	"github.com/tatris-io/tatris/internal/common/consts"
-	"github.com/tatris-io/tatris/test/ut/prepare"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/tatris-io/tatris/internal/common/consts"
+	"github.com/tatris-io/tatris/test/ut/prepare"
 )
 
 func TestIngestHandler(t *testing.T) {

--- a/internal/ingestion/ingest_doc.go
+++ b/internal/ingestion/ingest_doc.go
@@ -4,10 +4,11 @@ package ingestion
 
 import (
 	"errors"
+	"time"
+
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/utils"
 	"github.com/tatris-io/tatris/internal/meta/metadata"
-	"time"
 )
 
 func IngestDocs(indexName string, docs []map[string]interface{}) error {

--- a/internal/meta/handler/index_handler.go
+++ b/internal/meta/handler/index_handler.go
@@ -5,11 +5,12 @@ package handler
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/tatris-io/tatris/internal/core"
 	"github.com/tatris-io/tatris/internal/meta/metadata"
 	"github.com/tatris-io/tatris/internal/protocol"
-	"net/http"
 )
 
 func CreateIndexHandler(c *gin.Context) {
@@ -35,7 +36,10 @@ func CreateIndexHandler(c *gin.Context) {
 func GetIndexHandler(c *gin.Context) {
 	indexName := c.Param("index")
 	if index, err := metadata.GetIndex(indexName); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"msg": "get index fail: " + indexName + ", " + err.Error()})
+		c.JSON(
+			http.StatusInternalServerError,
+			gin.H{"msg": "get index fail: " + indexName + ", " + err.Error()},
+		)
 	} else if index == nil {
 		c.JSON(http.StatusNotFound, gin.H{"msg": fmt.Sprintf("index not found: %s", indexName)})
 	} else {

--- a/internal/meta/handler/index_handler_test.go
+++ b/internal/meta/handler/index_handler_test.go
@@ -6,17 +6,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
-	"github.com/tatris-io/tatris/internal/common/consts"
-	"github.com/tatris-io/tatris/internal/protocol"
-	"github.com/tatris-io/tatris/test/ut/prepare"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/tatris-io/tatris/internal/common/consts"
+	"github.com/tatris-io/tatris/internal/protocol"
+	"github.com/tatris-io/tatris/test/ut/prepare"
 )
 
 func TestIndexHandler(t *testing.T) {

--- a/internal/meta/metadata/index_manager.go
+++ b/internal/meta/metadata/index_manager.go
@@ -7,16 +7,27 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/core"
 	"github.com/tatris-io/tatris/internal/meta/metadata/storage"
 	"github.com/tatris-io/tatris/internal/meta/metadata/storage/boltdb"
 	"github.com/tatris-io/tatris/internal/protocol"
-	"strings"
 )
 
 var metaStore storage.MetaStore
-var supportTypes = []string{"integer", "long", "float", "double", "boolean", "date", "keyword", "text"}
+
+var supportTypes = []string{
+	"integer",
+	"long",
+	"float",
+	"double",
+	"boolean",
+	"date",
+	"keyword",
+	"text",
+}
 
 func init() {
 	var err error

--- a/internal/meta/metadata/index_manager_test.go
+++ b/internal/meta/metadata/index_manager_test.go
@@ -5,9 +5,10 @@ package metadata
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/tatris-io/tatris/internal/protocol"
-	"testing"
 )
 
 type testItem struct {

--- a/internal/meta/metadata/storage/boltdb/boltdb.go
+++ b/internal/meta/metadata/storage/boltdb/boltdb.go
@@ -5,12 +5,13 @@ package boltdb
 
 import (
 	"bytes"
+	"os"
+	"path"
+
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/log/logger"
 	"github.com/tatris-io/tatris/internal/meta/metadata/storage"
 	"go.etcd.io/bbolt"
-	"os"
-	"path"
 )
 
 type BoltMetaStore struct {

--- a/internal/meta/metadata/storage/boltdb/boltdb_test.go
+++ b/internal/meta/metadata/storage/boltdb/boltdb_test.go
@@ -3,8 +3,9 @@
 package boltdb
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBoltMetaStore_Get(t *testing.T) {

--- a/internal/protocol/index.go
+++ b/internal/protocol/index.go
@@ -18,7 +18,8 @@ type Settings struct {
 	NumberOfReplicas int `json:"number_of_replicas,omitempty"`
 }
 
-// Mappings Mapping is the process of defining how a document, and the fields it contains, are stored and indexed.
+// Mappings Mapping is the process of defining how a document, and the fields it contains, are
+// stored and indexed.
 type Mappings struct {
 	// Type mappings, object fields and nested fields contain sub-fields, called properties.
 	Properties map[string]Property `json:"properties,omitempty"`

--- a/internal/query/handler/query_handler.go
+++ b/internal/query/handler/query_handler.go
@@ -4,11 +4,12 @@
 package handler
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/tatris-io/tatris/internal/protocol"
 	"github.com/tatris-io/tatris/internal/query"
-	"net/http"
-	"time"
 )
 
 func QueryHandler(c *gin.Context) {

--- a/internal/query/handler/query_handler_test.go
+++ b/internal/query/handler/query_handler_test.go
@@ -5,16 +5,17 @@ package handler
 import (
 	"bytes"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
-	"github.com/tatris-io/tatris/internal/common/consts"
-	"github.com/tatris-io/tatris/test/ut/prepare"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/tatris-io/tatris/internal/common/consts"
+	"github.com/tatris-io/tatris/test/ut/prepare"
 )
 
 func TestQueryHandler(t *testing.T) {

--- a/internal/query/query_doc.go
+++ b/internal/query/query_doc.go
@@ -6,14 +6,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/log/logger"
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/meta/metadata"
 	"github.com/tatris-io/tatris/internal/protocol"
 	"go.uber.org/zap"
-	"strconv"
-	"time"
 )
 
 func SearchDocs(request protocol.QueryRequest) (*protocol.Hits, error) {
@@ -52,7 +53,10 @@ func SearchDocs(request protocol.QueryRequest) (*protocol.Hits, error) {
 		totalValue += respHits.Total.Value
 		totalRelation = respHits.Total.Relation
 		for _, respHit := range respHits.Hits {
-			hits.Hits = append(hits.Hits, protocol.Hit{Index: respHit.Index, ID: respHit.ID, Source: respHit.Source})
+			hits.Hits = append(
+				hits.Hits,
+				protocol.Hit{Index: respHit.Index, ID: respHit.ID, Source: respHit.Source},
+			)
 		}
 		reader.Close()
 	}

--- a/test/ut/prepare/prepare.go
+++ b/test/ut/prepare/prepare.go
@@ -6,14 +6,15 @@ package prepare
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/tatris-io/tatris/internal/common/log/logger"
-	"github.com/tatris-io/tatris/internal/core"
-	"github.com/tatris-io/tatris/internal/ingestion"
-	"github.com/tatris-io/tatris/internal/meta/metadata"
 	"io"
 	"os"
 	"path"
 	"runtime"
+
+	"github.com/tatris-io/tatris/internal/common/log/logger"
+	"github.com/tatris-io/tatris/internal/core"
+	"github.com/tatris-io/tatris/internal/ingestion"
+	"github.com/tatris-io/tatris/internal/meta/metadata"
 )
 
 func GetIndex(version string) (*core.Index, error) {


### PR DESCRIPTION
## Which issue does this PR close?

None

## Rationale for this change
 
The code format was not strictly regulated. There are some excessively long lines lie in the source code, which harms readability.

## What changes are included in this PR?

* add `golines` which can format excessive long lines and imports in `.go` files.
* format the old code

## Are there any user-facing changes?

No.

## How does this change test

Pass the CI
