### PR TITLE
feat(meta): add API to detect if index exists

### DIFF
--- a/internal/meta/handler/index_handler.go
+++ b/internal/meta/handler/index_handler.go
@@ -47,6 +47,20 @@ func GetIndexHandler(c *gin.Context) {
 	}
 }
 
+func IndexExistHandler(c *gin.Context) {
+	indexName := c.Param("index")
+	if index, err := metadata.GetIndex(indexName); err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			gin.H{"msg": "get index fail: " + indexName + ", " + err.Error()},
+		)
+	} else if index == nil {
+		c.JSON(http.StatusNotFound, gin.H{"msg": fmt.Sprintf("index not found: %s", indexName)})
+	} else {
+		c.JSON(http.StatusOK, nil)
+	}
+}
+
 func DeleteIndexHandler(c *gin.Context) {
 	indexName := c.Param("index")
 	if err := metadata.DeleteIndex(indexName); err != nil {

--- a/internal/meta/handler/index_handler_test.go
+++ b/internal/meta/handler/index_handler_test.go
@@ -50,6 +50,24 @@ func TestIndexHandler(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 
+	t.Run("index_exist_Y", func(t *testing.T) {
+		gin.SetMode(gin.ReleaseMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		req := &http.Request{
+			URL:    &url.URL{},
+			Header: make(http.Header),
+		}
+		c.Request = req
+		p := gin.Params{}
+		p = append(p, gin.Param{Key: "index", Value: index.Name})
+		c.Params = p
+		IndexExistHandler(c)
+		getIndex := protocol.Index{}
+		json.Unmarshal(w.Body.Bytes(), &getIndex)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
 	t.Run("get_index", func(t *testing.T) {
 		gin.SetMode(gin.ReleaseMode)
 		w := httptest.NewRecorder()
@@ -91,5 +109,23 @@ func TestIndexHandler(t *testing.T) {
 		DeleteIndexHandler(c)
 		fmt.Println(w)
 		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("index_exist_N", func(t *testing.T) {
+		gin.SetMode(gin.ReleaseMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		req := &http.Request{
+			URL:    &url.URL{},
+			Header: make(http.Header),
+		}
+		c.Request = req
+		p := gin.Params{}
+		p = append(p, gin.Param{Key: "index", Value: index.Name})
+		c.Params = p
+		IndexExistHandler(c)
+		getIndex := protocol.Index{}
+		json.Unmarshal(w.Body.Bytes(), &getIndex)
+		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
 }

--- a/internal/service/router.go
+++ b/internal/service/router.go
@@ -77,4 +77,5 @@ func registerMeta(group *gin.RouterGroup) {
 	group.PUT("/:index", handler2.CreateIndexHandler)
 	group.GET("/:index", handler2.GetIndexHandler)
 	group.DELETE("/:index", handler2.DeleteIndexHandler)
+	group.HEAD("/:index", handler2.IndexExistHandler)
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #104 

## Rationale for this change
As mentioned in the issue #104 , it is supported to detect whether the specified index exists through the API.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Added routing rules and implementation for detecting the existence of indexes.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users can now check whether the specified index exists through the `HEAD` method of HTTP.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Unit tests in [index_handler_test.go](https://github.com/xiangwanpeng/tatris/blob/feat/index-exist/internal/meta/handler/index_handler_test.go#L114) passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
