### PR TITLE
fix: no default config found

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -45,7 +45,7 @@ func initLoggers(confPath string) {
 }
 
 func initServer(confPath string) {
-	serverConf := config.DefaultConfig()
+	serverConf := config.Cfg
 	content, err := os.ReadFile(confPath)
 	if err != nil {
 		logger.Panic("fail to open server conf, use the default settings instead", zap.Error(err))

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -12,10 +12,12 @@ import (
 
 var Cfg *Config
 
-var defaultCfg = Config{
-	Segment: segment{
-		MatureThreshold: 500,
-	},
+func init() {
+	Cfg = &Config{
+		Segment: segment{
+			MatureThreshold: 500,
+		},
+	}
 }
 
 type Config struct {
@@ -51,11 +53,6 @@ func (s *segment) verify() {
 // doVerify verifies the control parameters of all modules
 func (cfg *Config) doVerify() {
 	cfg.Segment.verify()
-}
-
-// DefaultConfig return a default configuration
-func DefaultConfig() *Config {
-	return &defaultCfg
 }
 
 func (cfg *Config) String() string {

--- a/internal/core/core_test/index_test.go
+++ b/internal/core/core_test/index_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tatris-io/tatris/internal/core"
+	"github.com/tatris-io/tatris/internal/core/config"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tatris-io/tatris/internal/common/consts"
@@ -41,7 +41,7 @@ func TestIndex(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(
 			t,
-			(int)(math.Ceil((float64(len(docs)))/core.SegmentMatureThreshold)),
+			(int)(math.Ceil((float64(len(docs)))/(float64(config.Cfg.Segment.MatureThreshold)))),
 			len(readers),
 		)
 


### PR DESCRIPTION
## Which issue does this PR close?

None.

## Rationale for this change
This PR is to fix the CI failure problem introduced by PR #103. 
In addition to entering the program from the cmd startup entry, I ignored that the execution of the unit test also needs to read some control parameters. In this case, the config is not initialized, so These tests fail.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
The default configuration will be set when the [config.Init()](https://github.com/xiangwanpeng/tatris/blob/fix/no_default_cfg/internal/core/config/config.go#L15) method is executed.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Regression test passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
