### PR TITLE
feat: support aggregation

### DIFF
--- a/internal/core/core_test/index_test.go
+++ b/internal/core/core_test/index_test.go
@@ -47,7 +47,7 @@ func TestIndex(t *testing.T) {
 			len(readers),
 		)
 
-		hits, err := query.SearchDocs(
+		resp, err := query.SearchDocs(
 			protocol.QueryRequest{
 				Index: index.Name,
 				Query: protocol.Query{Term: protocol.Term{"name": "elasticsearch"}},
@@ -55,7 +55,7 @@ func TestIndex(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(hits.Hits))
+		assert.Equal(t, 1, len(resp.Hits.Hits))
 	})
 }
 

--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -146,7 +146,6 @@ func (b *BlugeWriter) addField(
 	value interface{},
 	mappings *protocol.Mappings,
 ) error {
-	// TODO get index mapping, case field type(text、keyword、bool)
 	var bfield *bluge.TermField
 	switch key {
 	case consts.TimestampField:
@@ -220,5 +219,6 @@ func (b *BlugeWriter) addFieldByMappingType(
 			bfield = bluge.NewDateTimeField(key, date)
 		}
 	}
-	return bfield, err
+	// TODO Sortable、StoreValue、Aggregatable needs to be configured
+	return bfield.Sortable().StoreValue().Aggregatable(), err
 }

--- a/internal/indexlib/query_request.go
+++ b/internal/indexlib/query_request.go
@@ -3,18 +3,33 @@
 package indexlib
 
 type QueryRequest interface {
-	searcher()
+	SetAggs(aggregations map[string]Aggs)
+	GetAggs() map[string]Aggs
 }
 
 type BaseQuery struct {
 	Boost float64
+	Aggs  map[string]Aggs
 }
 
-func (m *BaseQuery) searcher() {
+func NewBaseQuery() *BaseQuery {
+	return &BaseQuery{}
+}
+
+func (m *BaseQuery) SetAggs(aggs map[string]Aggs) {
+	m.Aggs = aggs
+}
+
+func (m *BaseQuery) GetAggs() map[string]Aggs {
+	return m.Aggs
 }
 
 type MatchAllQuery struct {
 	*BaseQuery
+}
+
+func NewMatchAllQuery() *MatchAllQuery {
+	return &MatchAllQuery{BaseQuery: NewBaseQuery()}
 }
 
 type MatchQuery struct {
@@ -27,6 +42,10 @@ type MatchQuery struct {
 	Operator  string // OR, AND
 }
 
+func NewMatchQuery() *MatchQuery {
+	return &MatchQuery{BaseQuery: NewBaseQuery()}
+}
+
 type MatchPhraseQuery struct {
 	*BaseQuery
 	MatchPhrase string
@@ -35,10 +54,18 @@ type MatchPhraseQuery struct {
 	Slop        int // Defaults to 0
 }
 
+func NewMatchPhraseQuery() *MatchPhraseQuery {
+	return &MatchPhraseQuery{BaseQuery: NewBaseQuery()}
+}
+
 type QueryString struct {
 	*BaseQuery
 	Query    string
 	Analyzer string
+}
+
+func NewQueryString() *QueryString {
+	return &QueryString{BaseQuery: NewBaseQuery()}
 }
 
 type TermQuery struct {
@@ -47,14 +74,26 @@ type TermQuery struct {
 	Field string
 }
 
+func NewTermQuery() *TermQuery {
+	return &TermQuery{BaseQuery: NewBaseQuery()}
+}
+
 type TermsQuery struct {
 	*BaseQuery
 	Terms map[string]*Terms
 }
 
+func NewTermsQuery() *TermsQuery {
+	return &TermsQuery{BaseQuery: NewBaseQuery()}
+}
+
 type Terms struct {
 	*BaseQuery
 	Fields []string
+}
+
+func NewTerms() *Terms {
+	return &Terms{BaseQuery: NewBaseQuery()}
 }
 
 type BooleanQuery struct {
@@ -66,9 +105,17 @@ type BooleanQuery struct {
 	MinShould int
 }
 
+func NewBooleanQuery() *BooleanQuery {
+	return &BooleanQuery{BaseQuery: NewBaseQuery()}
+}
+
 type RangeQuery struct {
 	*BaseQuery
 	Range map[string]*RangeVal
+}
+
+func NewRangeQuery() *RangeQuery {
+	return &RangeQuery{BaseQuery: NewBaseQuery()}
 }
 
 type RangeVal struct {
@@ -76,4 +123,41 @@ type RangeVal struct {
 	GTE interface{}
 	LT  interface{}
 	LTE interface{}
+}
+
+type Aggs struct {
+	Terms        *AggTerms
+	NumericRange *AggNumericRange
+	Sum          *AggMetric
+	Min          *AggMetric
+	Max          *AggMetric
+	Avg          *AggMetric
+	Cardinality  *AggMetric
+	WeightedAvg  *AggWeightedAvg
+	Aggs         map[string]Aggs
+}
+
+type AggMetric struct {
+	Field string
+}
+
+type AggWeightedAvg struct {
+	Value  *AggMetric
+	Weight *AggMetric
+}
+
+type AggTerms struct {
+	Field string
+	Size  int
+}
+
+type AggNumericRange struct {
+	Field  string
+	Ranges []NumericRange
+	Keyed  bool
+}
+
+type NumericRange struct {
+	To   float64
+	From float64
 }

--- a/internal/indexlib/query_response.go
+++ b/internal/indexlib/query_response.go
@@ -5,8 +5,9 @@ package indexlib
 import "time"
 
 type QueryResponse struct {
-	Took int64 `json:"took"`
-	Hits Hits  `json:"hits"`
+	Took         int64                   `json:"took"`
+	Hits         Hits                    `json:"hits"`
+	Aggregations map[string]AggsResponse `json:"aggregations"`
 }
 
 type Hits struct {
@@ -24,4 +25,9 @@ type Hit struct {
 	ID        string                 `json:"_id"`
 	Source    map[string]interface{} `json:"_source"`
 	Timestamp time.Time              `json:"_timestamp"`
+}
+
+type AggsResponse struct {
+	Value   interface{} `json:"value,omitempty"`   // metric aggregation
+	Buckets interface{} `json:"buckets,omitempty"` // bucket aggregation
 }

--- a/internal/protocol/query_request.go
+++ b/internal/protocol/query_request.go
@@ -4,9 +4,10 @@
 package protocol
 
 type QueryRequest struct {
-	Index string `json:"index"`
-	Query Query  `json:"query"`
-	Size  int64  `json:"size"`
+	Index string          `json:"index"`
+	Query Query           `json:"query"`
+	Aggs  map[string]Aggs `json:"aggs"`
+	Size  int64           `json:"size"`
 }
 
 // TODO: to be supplemented
@@ -62,4 +63,41 @@ type Bool struct {
 	Should             []*Query `json:"should,omitempty"`
 	Filter             []*Query `json:"filter,omitempty"`
 	MinimumShouldMatch string   `json:"minimum_should_match,omitempty"`
+}
+
+type Aggs struct {
+	Terms        *AggTerms        `json:"terms,omitempty"`
+	NumericRange *AggNumericRange `json:"range"`
+	Sum          *AggMetric       `json:"sum,omitempty"`
+	Min          *AggMetric       `json:"min,omitempty"`
+	Max          *AggMetric       `json:"max,omitempty"`
+	Avg          *AggMetric       `json:"avg,omitempty"`
+	Cardinality  *AggMetric       `json:"cardinality,omitempty"`
+	WeightedAvg  *AggWeightedAvg  `json:"weighted_avg,omitempty"`
+	Aggs         map[string]Aggs  `json:"aggs,omitempty"`
+}
+
+type AggMetric struct {
+	Field string `json:"field"`
+}
+
+type AggWeightedAvg struct {
+	Value  *AggMetric `json:"value"`
+	Weight *AggMetric `json:"weight"`
+}
+
+type AggTerms struct {
+	Field string `json:"field"`
+	Size  int    `json:"size"`
+}
+
+type AggNumericRange struct {
+	Field  string         `json:"field"`
+	Ranges []NumericRange `json:"ranges"`
+	Keyed  bool           `json:"keyed"`
+}
+
+type NumericRange struct {
+	To   float64 `json:"to"`
+	From float64 `json:"from"`
 }

--- a/internal/protocol/query_response.go
+++ b/internal/protocol/query_response.go
@@ -3,12 +3,13 @@
 package protocol
 
 type QueryResponse struct {
-	Took     int64       `json:"took"` // unit: ms
-	TimedOut bool        `json:"timedOut"`
-	Shards   Shards      `json:"_shards"`
-	Hits     Hits        `json:"hits"`
-	Error    interface{} `json:"error"`
-	Status   int32       `json:"status"`
+	Took         int64                   `json:"took"` // unit: ms
+	TimedOut     bool                    `json:"timedOut"`
+	Shards       Shards                  `json:"_shards"`
+	Hits         Hits                    `json:"hits"`
+	Error        interface{}             `json:"error,omitempty"`
+	Status       int32                   `json:"status"`
+	Aggregations map[string]AggsResponse `json:"aggregations,omitempty"`
 }
 
 type Shards struct {
@@ -32,4 +33,9 @@ type Hit struct {
 	Index  string                 `json:"_index"`
 	ID     string                 `json:"_id"`
 	Source map[string]interface{} `json:"_source"`
+}
+
+type AggsResponse struct {
+	Value   interface{} `json:"value,omitempty"`
+	Buckets interface{} `json:"buckets,omitempty"`
 }

--- a/internal/query/handler/query_handler.go
+++ b/internal/query/handler/query_handler.go
@@ -5,7 +5,6 @@ package handler
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tatris-io/tatris/internal/protocol"
@@ -13,20 +12,16 @@ import (
 )
 
 func QueryHandler(c *gin.Context) {
-	start := time.Now()
 	indexName := c.Param("index")
 	queryRequest := protocol.QueryRequest{Size: 10}
 	if err := c.ShouldBind(&queryRequest); err != nil {
 		c.String(http.StatusBadRequest, `invalid request`)
 	}
 	queryRequest.Index = indexName
-	hits, err := query.SearchDocs(queryRequest)
+	resp, err := query.SearchDocs(queryRequest)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"msg": err.Error()})
 	} else {
-		resp := protocol.QueryResponse{}
-		resp.Hits = *hits
-		resp.Took = time.Since(start).Milliseconds()
 		c.JSON(http.StatusOK, resp)
 	}
 }

--- a/internal/query/handler/query_handler_test.go
+++ b/internal/query/handler/query_handler_test.go
@@ -44,6 +44,11 @@ func TestQueryHandler(t *testing.T) {
 		c.Request.Body = io.NopCloser(bytes.NewBufferString(queryRequest))
 		QueryHandler(c)
 		fmt.Println(w)
+
+		c.Request.Body = io.NopCloser(bytes.NewBufferString(queryWithAggRequest))
+		QueryHandler(c)
+		fmt.Println(w)
+
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 }
@@ -78,6 +83,51 @@ const queryRequest = `
           }
         }
       ]
+    }
+  }
+}
+`
+
+const queryWithAggRequest = `
+{
+  "size": 20,
+  "aggs": {
+    "lang": {
+     "terms": {
+       "field": "lang",
+       "size": 10
+     },
+     "aggs": {
+       "avg_forks": {
+         "avg": {
+           "field": "forks"
+         }
+       },
+       "sum_stars": {
+         "sum": {
+           "field": "stars"
+         }
+       },
+       "cardinality_name": {
+         "cardinality": {
+           "field": "name"
+         }
+       },
+      "range_forks": {
+       "range": {
+         "field": "forks",
+         "ranges": [
+           {
+             "to": 10000
+           },
+           {
+             "from": 10000,
+             "to": 20000
+           }
+         ]
+       }
+      }
+     }
     }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #107

## Rationale for this change
 An aggregation summarizes your data as metrics, statistics, or other analytics. The tatris needs to implement the following first

- metrics aggregations that calculate metrics, such as a sum or average, from field values
- bucket aggregations that group documents into buckets, also called bins, based on field values, ranges, or other criteria
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
**metrics aggregation**
- sum
- min
- max
- avg
- cardinality
- weighted_avg

**bucket aggregations**
- terms
- range

**nested aggregations**
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
`internal/query/handler/query_handler_test.go`
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
