### PR TITLE
fix: save index after updating statistics

### DIFF
--- a/internal/core/shard.go
+++ b/internal/core/shard.go
@@ -25,7 +25,7 @@ type Shard struct {
 	ShardID  int
 	Segments []*Segment
 	Stat     ShardStat
-	Wal      log.WalLog
+	wal      log.WalLog
 	lock     sync.RWMutex
 }
 
@@ -75,7 +75,7 @@ func (shard *Shard) CheckSegments() {
 func (shard *Shard) OpenWAL() (log.WalLog, error) {
 	shard.lock.Lock()
 	defer shard.lock.Unlock()
-	if shard.Wal == nil {
+	if shard.wal == nil {
 		options := config.Cfg.Wal
 		name := shard.GetName()
 		p := path.Join(consts.DefaultWALPath, name)
@@ -98,9 +98,9 @@ func (shard *Shard) OpenWAL() (log.WalLog, error) {
 			return nil, err
 		}
 		twalLog.Log = l
-		shard.Wal = twalLog
+		shard.wal = twalLog
 	}
-	return shard.Wal, nil
+	return shard.wal, nil
 }
 
 func (shard *Shard) UpdateStat(min, max time.Time, docs int64, wals uint64) {

--- a/internal/core/wal/wal.go
+++ b/internal/core/wal/wal.go
@@ -152,6 +152,10 @@ func ConsumeWAL(shard *core.Shard, wal log.WalLog) error {
 		return err
 	}
 	shard.UpdateStat(minTime, maxTime, int64(len(docs)), to)
+	err = metadata.SaveIndex(shard.Index)
+	if err != nil {
+		return err
+	}
 	// The id passed to func TruncateFront cannot be greater than the last index of the stock log
 	err = wal.TruncateFront(to)
 	if err != nil {


### PR DESCRIPTION
## Which issue does this PR close?

None.

## Rationale for this change
This is a bugfix, in order to fix the problem that the shard/segment statistics are forgotten to be persisted to the disk after being updated in memory, resulting in the loss of the WAL consumption point after the system restarts.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
[wal.go](https://github.com/xiangwanpeng/tatris/blob/fix/update-stat/internal/core/wal/wal.go) and [shard.go](https://github.com/xiangwanpeng/tatris/blob/fix/update-stat/internal/core/shard.go).
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and ut passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
