### PR TITLE
fix: fix match keyword field

### DIFF
--- a/internal/core/index.go
+++ b/internal/core/index.go
@@ -70,7 +70,7 @@ func (index *Index) GetReaderByTime(start, end int64) (indexlib.Reader, error) {
 	config := &indexlib.BaseConfig{
 		DataPath: consts.DefaultDataPath,
 	}
-	return manage.GetReader(config, indexes...)
+	return manage.GetReader(config, index.Mappings, indexes...)
 }
 
 func (index *Index) CheckMapping(docID string, doc map[string]interface{}) error {

--- a/internal/core/segment.go
+++ b/internal/core/segment.go
@@ -43,7 +43,7 @@ func (segment *Segment) GetWriter() (indexlib.Writer, error) {
 	config := &indexlib.BaseConfig{
 		DataPath: consts.DefaultDataPath,
 	}
-	writer, err := manage.GetWriter(config, segment.GetName())
+	writer, err := manage.GetWriter(config, segment.Shard.Index.Mappings, segment.GetName())
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (segment *Segment) GetReader() (indexlib.Reader, error) {
 	config := &indexlib.BaseConfig{
 		DataPath: consts.DefaultDataPath,
 	}
-	return manage.GetReader(config, segment.GetName())
+	return manage.GetReader(config, segment.Shard.Index.Mappings, segment.GetName())
 }
 
 func (segment *Segment) IsMature() bool {

--- a/internal/core/wal/wal.go
+++ b/internal/core/wal/wal.go
@@ -200,7 +200,7 @@ func persistDocs(shard *core.Shard,
 		zap.Int("segment", segment.SegmentID),
 		zap.Int("size", len(docs)),
 	)
-	err = writer.Batch(docs, shard.Index.Mappings)
+	err = writer.Batch(docs)
 	if err != nil {
 		return err
 	}

--- a/internal/indexlib/bluge/analyzer.go
+++ b/internal/indexlib/bluge/analyzer.go
@@ -1,0 +1,25 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
+package bluge
+
+import (
+	"strings"
+
+	"github.com/blugelabs/bluge/analysis"
+	"github.com/blugelabs/bluge/analysis/analyzer"
+)
+
+func generateAnalyzer(analyzerStr string) *analysis.Analyzer {
+	switch strings.ToUpper(analyzerStr) {
+	case "KEYWORD":
+		return analyzer.NewKeywordAnalyzer()
+	case "SIMPLE":
+		return analyzer.NewSimpleAnalyzer()
+	case "STANDARD":
+		return analyzer.NewStandardAnalyzer()
+	case "WEB":
+		return analyzer.NewWebAnalyzer()
+	default:
+		return analyzer.NewStandardAnalyzer()
+	}
+}

--- a/internal/indexlib/indexlib_test/indexlib_test.go
+++ b/internal/indexlib/indexlib_test/indexlib_test.go
@@ -31,7 +31,7 @@ func TestIndexLib(t *testing.T) {
 
 	// test
 	t.Run("test_write", func(t *testing.T) {
-		if writer, err := manage.GetWriter(&indexlib.BaseConfig{}, path.Join(consts.DefaultDataPath, index.Name)); err != nil {
+		if writer, err := manage.GetWriter(&indexlib.BaseConfig{}, index.Mappings, path.Join(consts.DefaultDataPath, index.Name)); err != nil {
 			t.Fatalf("get writer error: %s", err.Error())
 		} else {
 			defer writer.Close()
@@ -44,7 +44,7 @@ func TestIndexLib(t *testing.T) {
 					}
 					doc[consts.IDField] = docID
 				}
-				err = writer.Insert(ID, doc, index.Mappings)
+				err = writer.Insert(ID, doc)
 				if err != nil {
 					t.Fatalf("write fail: %s", err.Error())
 				}
@@ -56,6 +56,7 @@ func TestIndexLib(t *testing.T) {
 	t.Run("test_read", func(t *testing.T) {
 		reader, err := manage.GetReader(
 			&indexlib.BaseConfig{},
+			index.Mappings,
 			path.Join(consts.DefaultDataPath, index.Name),
 		)
 		if err != nil {
@@ -65,8 +66,8 @@ func TestIndexLib(t *testing.T) {
 
 		// test match query
 		matchQuery := indexlib.NewMatchQuery()
-		matchQuery.Match = "elasticsearch"
-		matchQuery.Field = "name"
+		matchQuery.Match = "Java"
+		matchQuery.Field = "lang"
 		resp, err := reader.Search(context.Background(), matchQuery, -1)
 		assert.NoError(t, err)
 		respJSON, err := json.Marshal(resp)
@@ -75,8 +76,8 @@ func TestIndexLib(t *testing.T) {
 
 		// test term query
 		termQuery := indexlib.NewTermQuery()
-		termQuery.Term = "elasticsearch"
-		termQuery.Field = "name"
+		termQuery.Term = "Java"
+		termQuery.Field = "lang"
 		termResp, err := reader.Search(context.Background(), termQuery, 10)
 		assert.NoError(t, err)
 		termRespJSON, err := json.Marshal(termResp)

--- a/internal/indexlib/manage/manage.go
+++ b/internal/indexlib/manage/manage.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"log"
 
+	"github.com/tatris-io/tatris/internal/protocol"
+
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/bluge"
 )
@@ -17,7 +19,11 @@ var ErrIndexMustBeSet = errors.New("index must be set")
 // This means that changes made to the index after the reader is obtained never affect the results
 // returned by this reader. This also means that this Reader is holding onto resources and MUST be
 // closed when it is no longer needed.
-func GetReader(config *indexlib.BaseConfig, index ...string) (indexlib.Reader, error) {
+func GetReader(
+	config *indexlib.BaseConfig,
+	mappings *protocol.Mappings,
+	index ...string,
+) (indexlib.Reader, error) {
 	if len(index) == 0 {
 		return nil, ErrIndexMustBeSet
 	}
@@ -30,7 +36,7 @@ func GetReader(config *indexlib.BaseConfig, index ...string) (indexlib.Reader, e
 
 	switch config.IndexLibType {
 	case indexlib.BlugeIndexLibType:
-		blugeReader := bluge.NewBlugeReader(config, index...)
+		blugeReader := bluge.NewBlugeReader(config, mappings, index...)
 		err := blugeReader.OpenReader()
 		if err != nil {
 			log.Printf("bluge open reader error: %s", err)
@@ -46,7 +52,11 @@ func GetReader(config *indexlib.BaseConfig, index ...string) (indexlib.Reader, e
 // processes from opening a writer while this one is still open. This does not affect Readers that
 // are already open, and it does not prevent new Readers from being opened,
 // but it does mean care care should be taken to close the Writer when you done.
-func GetWriter(config *indexlib.BaseConfig, index string) (indexlib.Writer, error) {
+func GetWriter(
+	config *indexlib.BaseConfig,
+	mappings *protocol.Mappings,
+	index string,
+) (indexlib.Writer, error) {
 	if index == "" {
 		return nil, errors.New("no index specified")
 	}
@@ -54,7 +64,7 @@ func GetWriter(config *indexlib.BaseConfig, index string) (indexlib.Writer, erro
 
 	switch baseConfig.IndexLibType {
 	case indexlib.BlugeIndexLibType:
-		blugeWriter := bluge.NewBlugeWriter(baseConfig, index)
+		blugeWriter := bluge.NewBlugeWriter(baseConfig, mappings, index)
 		err := blugeWriter.OpenWriter()
 		if err != nil {
 			log.Printf("bluge open writer error: %s", err)

--- a/internal/indexlib/writer.go
+++ b/internal/indexlib/writer.go
@@ -2,12 +2,10 @@
 
 package indexlib
 
-import "github.com/tatris-io/tatris/internal/protocol"
-
 type Writer interface {
 	OpenWriter() error
-	Insert(docID string, doc map[string]interface{}, mappings *protocol.Mappings) error
-	Batch(docs map[string]map[string]interface{}, mappings *protocol.Mappings) error
+	Insert(docID string, doc map[string]interface{}) error
+	Batch(docs map[string]map[string]interface{}) error
 	Reader() (Reader, error)
 	Close()
 }

--- a/internal/query/handler/query_handler.go
+++ b/internal/query/handler/query_handler.go
@@ -16,7 +16,10 @@ func QueryHandler(c *gin.Context) {
 	indexName := c.Param("index")
 	queryRequest := protocol.QueryRequest{Size: 10}
 	if err := c.ShouldBind(&queryRequest); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"msg": fmt.Sprintf("invalid request: %+v", err.Error())})
+		c.JSON(
+			http.StatusBadRequest,
+			gin.H{"msg": fmt.Sprintf("invalid request: %+v", err.Error())},
+		)
 		return
 	}
 

--- a/internal/query/query_doc.go
+++ b/internal/query/query_doc.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/tatris-io/tatris/internal/indexlib/manage"
 	"strconv"
 	"time"
+
+	"github.com/tatris-io/tatris/internal/indexlib/manage"
 
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/log/logger"


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 The `match query` does not match when the `bluge` `keyword` field value contains uppercase letters
Need set `KEYWORD` analyzer when field type is `keyword`

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Interface `manager.getReader ` add a param mapping
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
`internal/indexlib/indexlib_test/indexlib_test.go`
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
