### PR TITLE
fix: close underlying writer when segment matures

### DIFF
--- a/internal/common/errs/error.go
+++ b/internal/common/errs/error.go
@@ -13,6 +13,7 @@ var (
 	ErrNoSegmentMatched   = errors.New("no segment matched")
 	ErrIndexLibNotSupport = errors.New("index lib not support")
 	ErrSpecifyDirAsFile   = errors.New("specify directory as file")
+	ErrSegmentReadonly    = errors.New("segment is readonly")
 )
 
 func IsIndexNotFound(err error) bool {

--- a/internal/core/core_test/index_test.go
+++ b/internal/core/core_test/index_test.go
@@ -39,6 +39,9 @@ func TestIndex(t *testing.T) {
 		}
 		assert.NotNil(t, index.GetShardByRouting())
 		reader, err := index.GetReaderByTime(start.Unix(), time.Now().UnixMilli())
+		if reader != nil {
+			defer reader.Close()
+		}
 		assert.NoError(t, err)
 		assert.Equal(
 			t,

--- a/internal/core/shard.go
+++ b/internal/core/shard.go
@@ -66,6 +66,9 @@ func (shard *Shard) CheckSegments() {
 		if lastedSegment == nil || lastedSegment.IsMature() {
 			newID := shard.GetSegmentNum()
 			shard.addSegment(newID)
+			if lastedSegment != nil {
+				lastedSegment.onMature()
+			}
 			logger.Info(
 				"add segment",
 				zap.String("index", shard.Index.Name),
@@ -139,10 +142,8 @@ func (shard *Shard) UpdateStat(min, max time.Time, docs int64, wals uint64) {
 }
 
 func (shard *Shard) addSegment(segmentID int) {
-	segments := shard.Segments
-	if len(segments) == 0 {
-		segments = make([]*Segment, 0)
-		shard.Segments = segments
-	}
-	shard.Segments = append(segments, &Segment{Shard: shard, SegmentID: segmentID, Stat: Stat{}})
+	shard.Segments = append(
+		shard.Segments,
+		&Segment{Shard: shard, SegmentID: segmentID, Stat: Stat{}},
+	)
 }

--- a/internal/indexlib/manage/manage.go
+++ b/internal/indexlib/manage/manage.go
@@ -40,7 +40,7 @@ func GetReader(
 // GetWriter Writer’s hold an exclusive-lock on their underlying directory which prevents other
 // processes from opening a writer while this one is still open. This does not affect Readers that
 // are already open, and it does not prevent new Readers from being opened,
-// but it does mean care care should be taken to close the Writer when you done.
+// but it does mean care should be taken to close the Writer when your work done.
 func GetWriter(
 	config *indexlib.BaseConfig,
 	mappings *protocol.Mappings,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #135 

## Rationale for this change
This PR fix the a resource leak point.

## What changes are included in this PR?
Close the underlying writer then the segment matures.

## Are there any user-facing changes?
None.

## How does this change test
CI and ut passed.
