### PR TITLE
fix: cache index after unmarshal

### DIFF
--- a/internal/meta/metadata/index_manager.go
+++ b/internal/meta/metadata/index_manager.go
@@ -97,6 +97,7 @@ func GetIndex(indexName string) (*core.Index, error) {
 				}
 			}
 		}
+		metaCache.Set(index.Name, index, cache.NoExpiration)
 		return index, nil
 	}
 }

--- a/internal/meta/metadata/index_manager_test.go
+++ b/internal/meta/metadata/index_manager_test.go
@@ -5,8 +5,10 @@ package metadata
 
 import (
 	"encoding/json"
+	"github.com/tatris-io/tatris/internal/core"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tatris-io/tatris/internal/common/consts"
 
@@ -94,4 +96,25 @@ func TestDynamicMappingCheck(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetIndexSameInstance(t *testing.T) {
+	version := time.Now().Format(time.RFC3339Nano)
+	err := SaveIndex(&core.Index{
+		Index: &protocol.Index{
+			Name: version,
+		},
+	})
+	assert.NoErrorf(t, err, "SaveIndex")
+
+	// clear meta cache
+	metaCache.Flush()
+
+	index1, err := GetIndex(version)
+	assert.NoError(t, err, "GetIndex 1")
+
+	index2, err := GetIndex(version)
+	assert.NoError(t, err, "GetIndex 2")
+
+	assert.Same(t, index1, index2, "GetIndex must return same instance for the same name")
 }


### PR DESCRIPTION
## Rationale for this change
Currently `metadata.GetIndex` returns new index instance every call. So all cached properties in shards of index are missed when new index instance is returned.

## What changes are included in this PR?
Cache index instance after unmarshal

## Are there any user-facing changes?
No

## How does this change test
Add UT
