### PR TITLE
feat: reuse readers as much as possible

### DIFF
--- a/internal/core/reader.go
+++ b/internal/core/reader.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package core
+
+import (
+	"github.com/pkg/errors"
+	"github.com/tatris-io/tatris/internal/common/errs"
+	"github.com/tatris-io/tatris/internal/common/log/logger"
+	"github.com/tatris-io/tatris/internal/indexlib"
+	"github.com/tatris-io/tatris/internal/indexlib/bluge"
+	"go.uber.org/zap"
+)
+
+// mergeReader merges opened readers into one indexlib.Reader instance. Now the provided reader must
+// be type of *bluge.BlugeReader.
+func mergeReader(config *indexlib.BaseConfig, readers ...indexlib.Reader) (indexlib.Reader, error) {
+	indexlib.SetDefaultConfig(config)
+	switch config.IndexLibType {
+	case indexlib.BlugeIndexLibType:
+		blugeReader, err := bluge.MergeReader(config, readers...)
+		if err != nil {
+			logger.Error("bluge fail to merge readers", zap.Error(err))
+			return nil, err
+		}
+		err = blugeReader.OpenReader()
+		if err != nil {
+			logger.Error("bluge open reader failed", zap.Error(err))
+			return nil, err
+		}
+		return blugeReader, nil
+	default:
+		return nil, errs.ErrIndexLibNotSupport
+	}
+}
+
+// MergeSegmentReader merges segment readers into one indexlib.Reader instance. Now the provided
+// reader must be type of *bluge.BlugeReader.
+func MergeSegmentReader(
+	config *indexlib.BaseConfig,
+	segments ...*Segment,
+) (indexlib.Reader, error) {
+	readers := make([]indexlib.Reader, 0, len(segments))
+	var lastGetReaderErr error
+	for _, segment := range segments {
+		if reader, err := segment.GetReader(); err == nil {
+			readers = append(readers, reader)
+		} else {
+			lastGetReaderErr = err
+			logger.Error("fail to open segment reader", zap.String("segment", segment.GetName()), zap.Error(err))
+		}
+	}
+	if len(readers) == 0 {
+		return nil, errors.Wrap(lastGetReaderErr, "fail to open segment reader")
+	}
+
+	merged, err := mergeReader(config, readers...)
+	if err != nil {
+		for _, reader := range readers {
+			reader.Close()
+		}
+	}
+	return merged, err
+}

--- a/internal/core/segment.go
+++ b/internal/core/segment.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -20,13 +21,33 @@ import (
 )
 
 // Segment is a physical split of the index under a shard
+
+const (
+	// SegmentStatusWritable means segment is the latest segment of shard and is writable.
+	// GetReaders returns a reader from the underlying writer, which can be used to search data near
+	// real-time.
+	SegmentStatusWritable uint8 = iota
+	// SegmentStatusReadonly means segment is readonly. So the writer is always nil, and GetWriter
+	// returns an error.
+	// GetReader uses ReaderCache to ensure opening same only once.
+	SegmentStatusReadonly
+)
+
 type Segment struct {
 	Shard     *Shard `json:"-"`
 	SegmentID int
 	Stat      Stat
-	lock      sync.RWMutex
+	lock      sync.Mutex
 	writer    indexlib.Writer
-	readonly  bool
+	readerRef int
+	status    uint8
+}
+
+func (segment *Segment) Status() uint8 {
+	segment.lock.Lock()
+	defer segment.lock.Unlock()
+
+	return segment.status
 }
 
 func (segment *Segment) GetName() string {
@@ -39,16 +60,22 @@ func (segment *Segment) GetName() string {
 }
 
 func (segment *Segment) GetWriter() (indexlib.Writer, error) {
-	if segment.writer != nil {
-		return segment.writer, nil
-	}
 	segment.lock.Lock()
 	defer segment.lock.Unlock()
 
-	if segment.readonly {
+	if segment.Readonly() {
 		return nil, errs.ErrSegmentReadonly
 	}
 
+	if segment.writer != nil {
+		return segment.writer, nil
+	}
+
+	return segment.openWriter()
+}
+
+// openWriter open underlying writer
+func (segment *Segment) openWriter() (indexlib.Writer, error) {
 	// open a writer
 	config := &indexlib.BaseConfig{
 		DataPath: consts.DefaultDataPath,
@@ -66,15 +93,71 @@ func (segment *Segment) GetWriter() (indexlib.Writer, error) {
 	return writer, nil
 }
 
+func (segment *Segment) openReaderFromWriter() (indexlib.Reader, error) {
+	if segment.writer == nil {
+		return nil, errors.New("writer is nil")
+	}
+	reader, err := segment.writer.Reader()
+	if err != nil {
+		return nil, err
+	}
+	segment.readerRef++
+	wrap := &indexlib.HookReader{
+		Reader: reader,
+		CloseHook: func(reader indexlib.Reader) {
+			reader.Close()
+			segment.onReaderClose()
+		},
+	}
+	return wrap, nil
+}
+
+func (segment *Segment) onReaderClose() {
+	segment.lock.Lock()
+	defer segment.lock.Unlock()
+
+	segment.readerRef--
+
+	if segment.status == SegmentStatusReadonly && segment.readerRef == 0 {
+		segment.writer.Close()
+		segment.writer = nil
+	}
+}
+
+// GetReader returns a reader snapshot of current segment. So docs wrote this func returns are
+// invisible to returned reader.
+// Returned reader must be closed after use.
 func (segment *Segment) GetReader() (indexlib.Reader, error) {
+	segment.lock.Lock()
+	defer segment.lock.Unlock()
+
+	if segment.status == SegmentStatusWritable && segment.writer != nil {
+		return segment.openReaderFromWriter()
+	}
+
 	config := &indexlib.BaseConfig{
 		DataPath: consts.DefaultDataPath,
 	}
-	return manage.GetReader(config, segment.GetName())
+
+	// The segment is readonly, so we can cache the result and reuse it
+	if segment.status == SegmentStatusReadonly {
+		return manage.GetReaderUsingCache(config, segment.GetName())
+	}
+
+	// The segment is never write since server startup. So we force open the writer here.
+	_, err := segment.openWriter()
+	if err != nil {
+		return nil, err
+	}
+	return segment.openReaderFromWriter()
 }
 
 func (segment *Segment) IsMature() bool {
 	return segment.Stat.DocNum > config.Cfg.Segment.MatureThreshold
+}
+
+func (segment *Segment) Readonly() bool {
+	return segment.status != SegmentStatusWritable
 }
 
 func (segment *Segment) MatchTime(start, end int64) bool {
@@ -114,8 +197,10 @@ func (segment *Segment) onMature() {
 	segment.lock.Lock()
 	defer segment.lock.Unlock()
 
-	segment.readonly = true
-	if segment.writer != nil {
+	segment.status = SegmentStatusReadonly
+
+	// close only when readerRef is 0
+	if segment.writer != nil && segment.readerRef == 0 {
 		segment.writer.Close()
 		segment.writer = nil
 	}

--- a/internal/core/shard.go
+++ b/internal/core/shard.go
@@ -79,6 +79,25 @@ func (shard *Shard) CheckSegments() {
 	}
 }
 
+// ForceAddSegment forces adding a segment to current shard
+func (shard *Shard) ForceAddSegment() {
+	shard.lock.Lock()
+	defer shard.lock.Unlock()
+
+	lastedSegment := shard.GetLatestSegment()
+	newID := shard.GetSegmentNum()
+	shard.addSegment(newID)
+	if lastedSegment != nil {
+		lastedSegment.onMature()
+	}
+	logger.Info(
+		"add segment",
+		zap.String("index", shard.Index.Name),
+		zap.Int("shard", shard.ShardID),
+		zap.Int("segment", newID),
+	)
+}
+
 func (shard *Shard) OpenWAL() (log.WalLog, error) {
 	shard.lock.Lock()
 	defer shard.lock.Unlock()

--- a/internal/indexlib/bluge/reader_test.go
+++ b/internal/indexlib/bluge/reader_test.go
@@ -1,0 +1,19 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+package bluge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloseHook(t *testing.T) {
+	closed := false
+	b := &BlugeReader{
+		closeHook: func(reader *BlugeReader) {
+			closed = true
+		},
+	}
+	b.Close()
+	assert.True(t, closed)
+}

--- a/internal/indexlib/manage/cache.go
+++ b/internal/indexlib/manage/cache.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package manage
+
+import (
+	"sync"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/tatris-io/tatris/internal/common/log/logger"
+	"github.com/tatris-io/tatris/internal/indexlib"
+)
+
+const (
+	// defaultCloseDelay
+	defaultCloseDelay = time.Minute
+	// defaultExpireTime
+	defaultExpireTime = 10 * time.Minute
+	// defaultExpireCheckInterval is the default check interval
+	defaultExpireCheckInterval = 1 * time.Minute
+)
+
+type (
+	// readerCache caches opened index reader whose construction has a significant cost.
+	// When a reader becomes idle, it will be closed automatically.
+	readerCache struct {
+		// cache stores segment name to its reader
+		// segment name format: ${index}/${shardId}/${segmentId}. for example 'foo/0/0'
+		cache      *cache.Cache
+		mutex      sync.RWMutex
+		closeDelay time.Duration
+	}
+)
+
+func newReaderCache(defaultExpiration, cleanupInterval, closeDelay time.Duration) *readerCache {
+	rc := &readerCache{
+		closeDelay: closeDelay,
+	}
+	c := cache.New(defaultExpiration, cleanupInterval)
+	c.OnEvicted(rc.onItemEvicted)
+	rc.cache = c
+	return rc
+}
+
+func (c *readerCache) PutIfAbsent(key string, reader indexlib.Reader) (indexlib.Reader, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if cached, ok := c.cache.Get(key); ok {
+		return cached.(*indexlib.HookReader), false
+	}
+
+	entry := &indexlib.HookReader{
+		Reader: reader,
+		CloseHook: func(reader indexlib.Reader) {
+			// no close
+		},
+	}
+
+	c.cache.SetDefault(key, entry)
+	return entry, true
+}
+
+// Get returns reader with specified key
+func (c *readerCache) Get(key string) (indexlib.Reader, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if cached, ok := c.cache.Get(key); ok {
+		return cached.(*indexlib.HookReader), true
+	}
+
+	return nil, false
+}
+
+func (c *readerCache) onItemEvicted(key string, i interface{}) {
+	reader := i.(*indexlib.HookReader)
+	time.AfterFunc(c.closeDelay, func() {
+		reader.Reader.Close()
+		logger.Infof("close cached reader %s", key)
+	})
+}

--- a/internal/indexlib/manage/cache_test.go
+++ b/internal/indexlib/manage/cache_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package manage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/tatris-io/tatris/internal/indexlib"
+	"github.com/tatris-io/tatris/internal/indexlib/bluge"
+)
+
+func TestReaderCache(t *testing.T) {
+	cache := newReaderCache(time.Second, 200*time.Millisecond, time.Second)
+
+	reader0 := &bluge.BlugeReader{}
+	reader1, put := cache.PutIfAbsent("foo", reader0)
+	assert.True(t, put)
+	assert.NotNil(t, reader1)
+	assert.IsType(t, &indexlib.HookReader{}, reader1)
+	assert.Same(t, indexlib.UnwrapReader(reader1), reader0)
+
+	reader2, put := cache.PutIfAbsent("foo", &bluge.BlugeReader{})
+	assert.False(t, put)
+	assert.NotNil(t, reader2)
+	assert.Same(t, reader1, reader2)
+
+	reader3, ok := cache.Get("foo")
+	assert.True(t, ok)
+	assert.NotNil(t, reader3)
+	assert.Same(t, reader1, reader3)
+
+	// 2 > 0.2(check) + 1(expire)
+	time.Sleep(2 * time.Second)
+
+	// expired
+	_, ok = cache.Get("foo")
+	assert.False(t, ok)
+}
+
+func TestCache(_ *testing.T) {
+	c := cache.New(time.Second, 200*time.Millisecond)
+	c.OnEvicted(func(key string, i interface{}) {
+		fmt.Println("evicted", key, i)
+	})
+	c.SetDefault("a", 1)
+	time.Sleep(500 * time.Millisecond)
+	c.SetDefault("a", 2)
+	time.Sleep(1 * time.Second)
+}

--- a/internal/indexlib/reader.go
+++ b/internal/indexlib/reader.go
@@ -6,9 +6,38 @@ import (
 	"context"
 )
 
-type Reader interface {
-	OpenReader() error
-	Search(ctx context.Context, req QueryRequest, limit int) (*QueryResponse, error)
-	Count() int
-	Close()
+type (
+	Reader interface {
+		OpenReader() error
+		Search(ctx context.Context, req QueryRequest, limit int) (*QueryResponse, error)
+		Count() int
+		Close()
+	}
+	// HookReader wraps another Reader and uses hooks to intercept Reader's funcs.
+	// It only supports intercepting the 'Close' func at the present time.
+	HookReader struct {
+		Reader
+		CloseHook func(Reader)
+	}
+)
+
+func (r *HookReader) Close() {
+	if r.CloseHook != nil {
+		r.CloseHook(r.Reader)
+	} else {
+		r.Reader.Close()
+	}
+}
+
+// UnwrapReader unwraps a reader to the underlying reader if it wraps other reader.
+func UnwrapReader(r Reader) Reader {
+	if r == nil {
+		return nil
+	}
+	switch x := r.(type) {
+	case *HookReader:
+		return x.Reader
+	default:
+		return r
+	}
 }

--- a/internal/query/query_doc.go
+++ b/internal/query/query_doc.go
@@ -12,8 +12,6 @@ import (
 	"github.com/tatris-io/tatris/internal/common/utils"
 	"github.com/xhit/go-str2duration/v2"
 
-	"github.com/tatris-io/tatris/internal/indexlib/manage"
-
 	"github.com/tatris-io/tatris/internal/core"
 
 	"github.com/tatris-io/tatris/internal/common/errs"
@@ -33,7 +31,7 @@ func SearchDocs(
 	if err != nil {
 		return nil, err
 	}
-	allSegments := make([]string, 0)
+	var allSegments []*core.Segment
 	for _, index := range indexes {
 		segments := index.GetSegmentsByTime(start, end)
 		allSegments = append(allSegments, segments...)
@@ -42,7 +40,7 @@ func SearchDocs(
 		// no match any segments, returns an appropriate response
 		return &protocol.QueryResponse{Hits: protocol.Hits{Hits: []protocol.Hit{}}}, nil
 	}
-	reader, err := manage.GetReader(&indexlib.BaseConfig{
+	reader, err := core.MergeSegmentReader(&indexlib.BaseConfig{
 		DataPath: consts.DefaultDataPath,
 	}, allSegments...)
 	if err != nil {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #143 

## Rationale for this change
Reuse readers as much as possible for better performance 

## What changes are included in this PR?
1. Get reader from writer for latest segment for near real-time data access
2. Cache and reuse readers of readonly segments

## Are there any user-facing changes?
None

## How does this change test
UT and local test
