### PR TITLE
fix: don't add unknown fields to doc

### DIFF
--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -173,7 +173,9 @@ func (b *BlugeWriter) addField(
 		}
 	}
 
-	bdoc.AddField(bfield)
+	if bfield != nil {
+		bdoc.AddField(bfield)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Rationale for this change
Currently we have:
```golang
func (b *BlugeWriter) addField(
	bdoc *bluge.Document,
	key string,
	value interface{},
	mappings *protocol.Mappings,
) error {
	var bfield *bluge.TermField
	switch key {
	case consts.TimestampField:
		bfield = bluge.NewDateTimeField(key, value.(time.Time))
	case consts.IDField:
		bfield = bluge.NewKeywordField(key, value.(string))
	default:
		if p, ok := mappings.Properties[key]; ok {
			field, err := b.addFieldByMappingType(p.Type, key, value)
			if err != nil {
				return err
			}
			bfield = field
		}
	}

	bdoc.AddField(bfield)
	return nil
}
```

When key is not in mappings.Properties, bfield is nil.
So we called bdoc.AddField(nil), which leading to nil panic in docuemnt.go#63 (bluge)
```golang
func (d Document) Analyze() {
	fieldOffsets := map[string]int{}
	for _, field := range d {
		if !field.Index() { // panic here because field is nil
			continue
		}
...
	}
}
```

We need to check bfield before adding it to bdoc.

## What changes are included in this PR?
Check bfield before adding it to bdoc.

## Are there any user-facing changes?
No

## How does this change test
None
