### PR TITLE
feat: improve index deletion

### DIFF
--- a/internal/common/errs/error.go
+++ b/internal/common/errs/error.go
@@ -30,6 +30,11 @@ func (e *IndexNotFoundError) Error() string {
 	return fmt.Sprintf("index: %s", e.Index)
 }
 
+func IsShardNotFound(err error) bool {
+	var notFoundErr *ShardNotFoundError
+	return err != nil && errors.As(err, &notFoundErr)
+}
+
 type ShardNotFoundError struct {
 	Index string `json:"index"`
 	Shard int    `json:"shard"`

--- a/internal/core/index.go
+++ b/internal/core/index.go
@@ -4,6 +4,9 @@
 package core
 
 import (
+	"os"
+	"path"
+
 	"github.com/pkg/errors"
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/errs"
@@ -107,6 +110,15 @@ func (index *Index) CheckMapping(doc protocol.Document) error {
 	}
 	index.Mappings.Properties = properties
 	return nil
+}
+
+func (index *Index) Close() error {
+	for _, shard := range index.Shards {
+		shard.Close()
+	}
+	// clear data
+	p := path.Join(consts.DefaultDataPath, index.Name)
+	return os.RemoveAll(p)
 }
 
 func getFieldType(

--- a/internal/core/segment.go
+++ b/internal/core/segment.go
@@ -205,3 +205,9 @@ func (segment *Segment) onMature() {
 		segment.writer = nil
 	}
 }
+
+func (segment *Segment) Close() {
+	// set the status to SegmentStatusReadonly,
+	// so immature segment can also close its writer after the last reader is closed
+	segment.status = SegmentStatusReadonly
+}

--- a/internal/meta/metadata/alias_manager.go
+++ b/internal/meta/metadata/alias_manager.go
@@ -115,6 +115,16 @@ func RemoveAlias(aliasTerm *protocol.AliasTerm) error {
 	return saveAlias(alias, aliasTerms, index, indexTerms)
 }
 
+func RemoveAliasesByIndex(index string) error {
+	terms := GetTermsByIndex(index)
+	for _, term := range terms {
+		if err := RemoveAlias(term); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func add(terms []*protocol.AliasTerm, term *protocol.AliasTerm) []*protocol.AliasTerm {
 	newTerms := remove(terms, term)
 	newTerms = append(newTerms, term)

--- a/internal/meta/metadata/index_manager_test.go
+++ b/internal/meta/metadata/index_manager_test.go
@@ -5,13 +5,9 @@ package metadata
 
 import (
 	"encoding/json"
+	"github.com/tatris-io/tatris/internal/common/consts"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/tatris-io/tatris/internal/core"
-
-	"github.com/tatris-io/tatris/internal/common/consts"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tatris-io/tatris/internal/protocol"
@@ -97,25 +93,4 @@ func TestDynamicMappingCheck(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestGetIndexSameInstance(t *testing.T) {
-	version := time.Now().Format(time.RFC3339Nano)
-	err := SaveIndex(&core.Index{
-		Index: &protocol.Index{
-			Name: version,
-		},
-	})
-	assert.NoErrorf(t, err, "SaveIndex")
-
-	// clear meta cache
-	indexCache.Flush()
-
-	index1, err := GetIndex(version)
-	assert.NoError(t, err, "GetIndex 1")
-
-	index2, err := GetIndex(version)
-	assert.NoError(t, err, "GetIndex 2")
-
-	assert.Same(t, index1, index2, "GetIndex must return same instance for the same name")
 }

--- a/internal/meta/metadata/metadata.go
+++ b/internal/meta/metadata/metadata.go
@@ -21,6 +21,10 @@ func init() {
 		logger.Panic("init metastore failed", zap.Error(err))
 	}
 
+	if err := LoadIndexes(); err != nil {
+		logger.Panic("load indexes failed", zap.Error(err))
+	}
+
 	if err := LoadAliases(); err != nil {
 		logger.Panic("load alias failed", zap.Error(err))
 	}

--- a/internal/service/handler/query_handler_test.go
+++ b/internal/service/handler/query_handler_test.go
@@ -118,7 +118,6 @@ func TestAliasQuery(t *testing.T) {
 		time.Sleep(time.Nanosecond * 1000)
 	}
 	indexes := make([]*core.Index, count)
-	//docses := make([]protocol.Document, count)
 	indexNames := make([]string, count)
 	aliasNames := make([]string, 0)
 	var err error


### PR DESCRIPTION
## Which issue does this PR close?

Closes #134 

## Rationale for this change
The current index deletion API of Tatris simply removes the content under the bucket `/index` in the metastore, and obsolete files such as data, WAL, and aliases will remain. I am solving this problem to achieve index lifecycle management.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- The index deletion API has been improved, it will cascade clear all information related to the target index.
- Some WAL-related codes in the `shard.go` have been moved to package `wal`, which is to converge WAL management to a unified entrance.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
If a user now calls the API to delete an index, all associated content will be removed.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regression tests passes.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
