### PR TITLE
feat: support histogram aggregation

### DIFF
--- a/internal/core/core_test/document_test.go
+++ b/internal/core/core_test/document_test.go
@@ -3,8 +3,9 @@
 package core_test
 
 import (
-	"github.com/tatris-io/tatris/internal/common/utils"
 	"testing"
+
+	"github.com/tatris-io/tatris/internal/common/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tatris-io/tatris/internal/common/consts"

--- a/internal/indexlib/bluge/aggregations/date_histogram.go
+++ b/internal/indexlib/bluge/aggregations/date_histogram.go
@@ -28,8 +28,8 @@ type DateHistogramAggregation struct {
 	format           string
 	timeZone         string
 	offset           string
-	extendedBounds   *indexlib.HistogramBound
-	hardBounds       *indexlib.HistogramBound
+	extendedBounds   *indexlib.DateHistogramBound
+	hardBounds       *indexlib.DateHistogramBound
 	aggregations     map[string]search.Aggregation
 	lessFunc         func(a, b *search.Bucket) bool
 	desc             bool
@@ -43,9 +43,10 @@ func NewDateHistogramAggregation(
 	format string,
 	timeZone string,
 	offset string,
+	minDocCount int,
 	extendedBounds,
-	hardBounds *indexlib.HistogramBound,
-	minDocCount int) *DateHistogramAggregation {
+	hardBounds *indexlib.DateHistogramBound,
+) *DateHistogramAggregation {
 	rv := &DateHistogramAggregation{
 		src:              field,
 		calendarInterval: calendarInterval,
@@ -108,8 +109,8 @@ type DateHistogramCalculator struct {
 	format           string
 	timeZone         *time.Location
 	offset           string
-	extendedBounds   *indexlib.HistogramBound
-	hardBounds       *indexlib.HistogramBound
+	extendedBounds   *indexlib.DateHistogramBound
+	hardBounds       *indexlib.DateHistogramBound
 	minNano          int64
 	maxNano          int64
 	aggregations     map[string]search.Aggregation

--- a/internal/indexlib/bluge/aggregations/histogram.go
+++ b/internal/indexlib/bluge/aggregations/histogram.go
@@ -1,0 +1,235 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
+// Package aggregations contains custom aggregation for bluge
+package aggregations
+
+import (
+	"math"
+	"sort"
+	"strconv"
+
+	"github.com/blugelabs/bluge/search"
+	"github.com/blugelabs/bluge/search/aggregations"
+	"github.com/tatris-io/tatris/internal/indexlib"
+)
+
+// Reference
+// https://github.com/blugelabs/bluge/blob/master/search/aggregations/terms.go
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html#_missing_value_2
+
+type HistogramAggregation struct {
+	src            search.NumericValuesSource
+	interval       float64
+	minDocCount    int
+	offset         float64
+	extendedBounds *indexlib.HistogramBound
+	hardBounds     *indexlib.HistogramBound
+	aggregations   map[string]search.Aggregation
+	lessFunc       func(a, b *search.Bucket) bool
+	desc           bool
+	sortFunc       func(p sort.Interface)
+}
+
+func NewHistogramAggregation(
+	field search.NumericValuesSource,
+	interval float64,
+	offset float64,
+	minDocCount int,
+	extendedBounds,
+	hardBounds *indexlib.HistogramBound,
+) *HistogramAggregation {
+	rv := &HistogramAggregation{
+		src:            field,
+		interval:       interval,
+		minDocCount:    minDocCount,
+		offset:         offset,
+		extendedBounds: extendedBounds,
+		hardBounds:     hardBounds,
+		desc:           false,
+		lessFunc: func(a, b *search.Bucket) bool {
+			fa, _ := strconv.ParseFloat(a.Name(), 64)
+			fb, _ := strconv.ParseFloat(b.Name(), 64)
+			return fa < fb
+		},
+		aggregations: make(map[string]search.Aggregation),
+		sortFunc:     sort.Sort,
+	}
+	rv.aggregations["count"] = aggregations.CountMatches()
+	return rv
+}
+
+func (d *HistogramAggregation) Fields() []string {
+	rv := d.src.Fields()
+	for _, agg := range d.aggregations {
+		rv = append(rv, agg.Fields()...)
+	}
+	return rv
+}
+
+func (d *HistogramAggregation) AddAggregation(name string, aggregation search.Aggregation) {
+	d.aggregations[name] = aggregation
+}
+
+func (d *HistogramAggregation) Calculator() search.Calculator {
+	return &HistogramCalculator{
+		src:            d.src,
+		interval:       d.interval,
+		minDocCount:    d.minDocCount,
+		offset:         d.offset,
+		extendedBounds: d.extendedBounds,
+		hardBounds:     d.hardBounds,
+		minValue:       math.MaxInt64,
+		maxValue:       math.MinInt64,
+		aggregations:   d.aggregations,
+		desc:           d.desc,
+		lessFunc:       d.lessFunc,
+		sortFunc:       d.sortFunc,
+		bucketsMap:     make(map[string]*search.Bucket),
+	}
+}
+
+type HistogramCalculator struct {
+	src            search.NumericValuesSource
+	interval       float64
+	minDocCount    int
+	offset         float64
+	extendedBounds *indexlib.HistogramBound
+	hardBounds     *indexlib.HistogramBound
+	minValue       float64
+	maxValue       float64
+	aggregations   map[string]search.Aggregation
+	bucketsList    []*search.Bucket
+	bucketsMap     map[string]*search.Bucket
+	total          int
+	other          int
+	desc           bool
+	lessFunc       func(a, b *search.Bucket) bool
+	sortFunc       func(p sort.Interface)
+}
+
+func (c *HistogramCalculator) Consume(d *search.DocumentMatch) {
+	c.total++
+	for _, value := range c.src.Numbers(d) {
+		// need to filter out the ones that aren't in the hard_bounds range
+		if hb := c.hardBounds; hb != nil {
+			if value < hb.Min || value > hb.Max {
+				return
+			}
+		}
+
+		if value < c.minValue {
+			c.minValue = value
+		}
+		if value > c.maxValue {
+			c.maxValue = value
+		}
+
+		key := c.calculatorBucketKey(value)
+		bucket, ok := c.bucketsMap[key]
+		if ok {
+			bucket.Consume(d)
+		} else {
+			newBucket := search.NewBucket(key, c.aggregations)
+			newBucket.Consume(d)
+			c.bucketsMap[key] = newBucket
+			c.bucketsList = append(c.bucketsList, newBucket)
+		}
+	}
+}
+
+func (c *HistogramCalculator) Merge(other search.Calculator) {
+	if other, ok := other.(*HistogramCalculator); ok {
+		c.total += other.total
+		for i := range other.bucketsList {
+			var foundLocal bool
+			for j := range c.bucketsList {
+				if other.bucketsList[i].Name() == c.bucketsList[j].Name() {
+					c.bucketsList[j].Merge(other.bucketsList[i])
+					foundLocal = true
+				}
+			}
+			if !foundLocal {
+				c.bucketsList = append(c.bucketsList, other.bucketsList[i])
+			}
+		}
+		c.Finish()
+	}
+}
+
+func (c *HistogramCalculator) Finish() {
+	// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html#search-aggregations-bucket-histogram-aggregation-extended-bounds
+	// extended_bounds is not filtering buckets
+	if eb := c.extendedBounds; eb != nil {
+		if min := eb.Min; min < c.minValue {
+			c.minValue = min
+		}
+		if max := eb.Max; max > c.maxValue {
+			c.maxValue = max
+		}
+	}
+	// hard_bounds maybe filtering buckets
+	if hb := c.hardBounds; hb != nil {
+		c.minValue = hb.Min
+		c.maxValue = hb.Max
+	}
+
+	// zero filling
+	if c.minDocCount == 0 {
+		for date := c.minValue; date < c.maxValue; {
+			key := c.calculatorBucketKey(date)
+			if _, ok := c.bucketsMap[key]; !ok {
+				newBucket := search.NewBucket(key, c.aggregations)
+				c.bucketsMap[key] = newBucket
+				c.bucketsList = append(c.bucketsList, newBucket)
+			}
+			date += c.interval
+		}
+	} else {
+		// filter bucket
+		i := 0
+		for _, bucket := range c.bucketsList {
+			if bucket.Count() >= uint64(c.minDocCount) {
+				c.bucketsList[i] = bucket
+				i++
+			}
+		}
+		c.bucketsList = c.bucketsList[:i]
+	}
+
+	if c.desc {
+		c.sortFunc(sort.Reverse(c))
+	} else {
+		c.sortFunc(c)
+	}
+
+	var notOther int
+	for _, bucket := range c.bucketsList {
+		notOther += int(bucket.Aggregations()["count"].(search.MetricCalculator).Value())
+	}
+	c.other = c.total - notOther
+}
+
+func (c *HistogramCalculator) Buckets() []*search.Bucket {
+	return c.bucketsList
+}
+
+func (c *HistogramCalculator) Other() int {
+	return c.other
+}
+
+func (c *HistogramCalculator) Len() int {
+	return len(c.bucketsList)
+}
+
+func (c *HistogramCalculator) Less(i, j int) bool {
+	return c.lessFunc(c.bucketsList[i], c.bucketsList[j])
+}
+
+func (c *HistogramCalculator) Swap(i, j int) {
+	c.bucketsList[i], c.bucketsList[j] = c.bucketsList[j], c.bucketsList[i]
+}
+
+func (c *HistogramCalculator) calculatorBucketKey(value float64) string {
+	bucketKey := math.Floor((value-c.offset)/c.interval)*c.interval + c.offset
+	return strconv.FormatFloat(bucketKey, 'f', -1, 64)
+}

--- a/internal/indexlib/bluge/reader.go
+++ b/internal/indexlib/bluge/reader.go
@@ -476,7 +476,7 @@ func (b *BlugeReader) generateAggregations(
 			dateHistogramAggregation := custom_aggregations.NewDateHistogramAggregation(
 				search.Field(d.Field), d.CalendarInterval,
 				d.FixedInterval, d.Format, d.TimeZone, d.Offset,
-				d.ExtendedBounds, d.HardBounds, d.MinDocCount,
+				d.MinDocCount, d.ExtendedBounds, d.HardBounds,
 			)
 			// nested aggregation (bucket aggregation need support)
 			if len(agg.Aggs) > 0 {
@@ -486,6 +486,18 @@ func (b *BlugeReader) generateAggregations(
 				}
 			}
 			result[name] = dateHistogramAggregation
+		} else if d := agg.Histogram; d != nil {
+			histogramAggregation := custom_aggregations.NewHistogramAggregation(
+				search.Field(d.Field),
+				d.Interval,
+				d.Offset,
+				d.MinDocCount,
+				d.ExtendedBounds,
+				d.HardBounds,
+			)
+			// when executing a histogram aggregation over a histogram field, no sub-aggregations
+			// are allowed.
+			result[name] = histogramAggregation
 		} else if agg.NumericRange != nil {
 			ranges := aggregations.Ranges(search.Field(agg.NumericRange.Field))
 			for _, value := range agg.NumericRange.Ranges {

--- a/internal/indexlib/query_request.go
+++ b/internal/indexlib/query_request.go
@@ -146,6 +146,7 @@ type Aggs struct {
 	Cardinality   *AggMetric
 	WeightedAvg   *AggWeightedAvg
 	DateHistogram *AggDateHistogram
+	Histogram     *AggHistogram
 	Aggs          map[string]Aggs
 }
 
@@ -192,11 +193,27 @@ type AggDateHistogram struct {
 	MinDocCount      int
 	Keyed            bool
 	Missing          string
-	ExtendedBounds   *HistogramBound
-	HardBounds       *HistogramBound
+	ExtendedBounds   *DateHistogramBound
+	HardBounds       *DateHistogramBound
+}
+
+type DateHistogramBound struct {
+	Min int64 `json:"min"`
+	Max int64 `json:"max"`
+}
+
+type AggHistogram struct {
+	Field          string
+	Interval       float64
+	MinDocCount    int
+	Offset         float64
+	Keyed          bool
+	Missing        string
+	ExtendedBounds *HistogramBound
+	HardBounds     *HistogramBound
 }
 
 type HistogramBound struct {
-	Min int64 `json:"min"` // nanos
-	Max int64 `json:"max"` // nanos
+	Min float64 `json:"min"`
+	Max float64 `json:"max"`
 }

--- a/internal/protocol/query_request.go
+++ b/internal/protocol/query_request.go
@@ -69,6 +69,7 @@ type Bool struct {
 type Aggs struct {
 	Terms         *AggTerms         `json:"terms,omitempty"`
 	DateHistogram *AggDateHistogram `json:"date_histogram,omitempty"`
+	Histogram     *AggHistogram     `json:"histogram,omitempty"`
 	NumericRange  *AggNumericRange  `json:"range"`
 	Sum           *AggMetric        `json:"sum,omitempty"`
 	Min           *AggMetric        `json:"min,omitempty"`
@@ -145,7 +146,19 @@ type AggDateHistogram struct {
 	HardBounds *HistogramBound `json:"hard_bounds"`
 }
 
+type AggHistogram struct {
+	Field          string          `json:"field"` // only support numeric type
+	Interval       float64         `json:"interval"`
+	MinDocCount    int             `json:"min_doc_count"`
+	Offset         float64         `json:"offset"`
+	Keyed          bool            `json:"keyed"`   // TODO
+	Order          interface{}     `json:"order"`   // TODO
+	Missing        string          `json:"missing"` // TODO
+	ExtendedBounds *HistogramBound `json:"extended_bounds"`
+	HardBounds     *HistogramBound `json:"hard_bounds"`
+}
+
 type HistogramBound struct {
-	Min float64 `json:"min"` // second/millis/micros/nanos
-	Max float64 `json:"max"` // second/millis/micros/nanos
+	Min float64 `json:"min"`
+	Max float64 `json:"max"`
 }

--- a/internal/service/handler/query_handler_test.go
+++ b/internal/service/handler/query_handler_test.go
@@ -53,7 +53,7 @@ func TestQuerySingleIndex(t *testing.T) {
 				zap.String("name", tt.name),
 				zap.String("index", tt.index),
 				zap.Int("code", w.Code),
-				//zap.Any("resp", w.Body),
+				zap.Any("resp", w.Body),
 			)
 			assert.Equal(t, http.StatusOK, w.Code)
 		})
@@ -100,7 +100,7 @@ func TestQueryMultipleIndexes(t *testing.T) {
 				zap.String("name", tt.name),
 				zap.String("index", tt.index),
 				zap.Int("code", w.Code),
-				//zap.Any("resp", w.Body),
+				zap.Any("resp", w.Body),
 			)
 			assert.Equal(t, http.StatusOK, w.Code)
 		})
@@ -341,6 +341,27 @@ var cases = []QueryCase{
 						  }
 						}
  					}
+				  }
+				}
+			  }
+			`,
+	},
+	{
+		name: "histogram",
+		req: `
+				{
+				  "size": 0,
+				  "aggs": {
+					"histogram": {
+					  "histogram": {
+						"field": "stars",
+						"interval": 100,
+						"min_doc_count": 0,
+						"hard_bounds": {
+							"min": 100,
+							"max": 1000
+						}
+					}
 				  }
 				}
 			  }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #157

## Rationale for this change
 Support histogram aggregation.
Use mode reference [elasticsearch histogram-aggregation ](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html)
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
```
{
    "size": 0,
    "aggs": {
        "histogram": {
            "histogram": {
                "field": "stars",
                "interval": 100,
                "min_doc_count": 0,
                "hard_bounds": {
                    "min": 100,
                    "max": 1000
                }
            }
        }
    }
}
```
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
internal/service/handler/query_handler_test.go
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
