### PR TITLE
feat: support percentiles aggregation

### DIFF
--- a/internal/indexlib/bluge/aggregations/percentiles.go
+++ b/internal/indexlib/bluge/aggregations/percentiles.go
@@ -1,0 +1,73 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
+package aggregations
+
+import (
+	"strconv"
+
+	"github.com/blugelabs/bluge/search"
+	"github.com/caio/go-tdigest"
+)
+
+type PercentilesMetric struct {
+	src         search.NumericValuesSource
+	percents    []float64
+	compression float64
+}
+
+func NewPercentiles(
+	src search.NumericValuesSource,
+	percents []float64,
+	compression float64,
+) *PercentilesMetric {
+	return &PercentilesMetric{
+		src:         src,
+		percents:    percents,
+		compression: compression,
+	}
+}
+
+func (c *PercentilesMetric) Fields() []string {
+	return c.src.Fields()
+}
+
+func (c *PercentilesMetric) Calculator() search.Calculator {
+	rv := &PercentilesCalculator{
+		src:      c.src,
+		percents: c.percents,
+	}
+	rv.tdigest, _ = tdigest.New(tdigest.Compression(c.compression))
+	return rv
+}
+
+type PercentilesCalculator struct {
+	src      search.NumericValuesSource
+	percents []float64
+	tdigest  *tdigest.TDigest
+}
+
+func (c *PercentilesCalculator) Value() map[string]float64 {
+	result := make(map[string]float64, len(c.percents))
+	for _, percent := range c.percents {
+		key := strconv.FormatFloat(percent, 'f', -1, 64)
+		result[key] = c.tdigest.Quantile(percent / 100)
+	}
+
+	return result
+}
+
+func (c *PercentilesCalculator) Consume(d *search.DocumentMatch) {
+	for _, val := range c.src.Numbers(d) {
+		_ = c.tdigest.Add(val)
+	}
+}
+
+func (c *PercentilesCalculator) Merge(other search.Calculator) {
+	if other, ok := other.(*PercentilesCalculator); ok {
+		_ = c.tdigest.Merge(other.tdigest)
+	}
+}
+
+func (c *PercentilesCalculator) Finish() {
+
+}

--- a/internal/indexlib/bluge/reader.go
+++ b/internal/indexlib/bluge/reader.go
@@ -516,6 +516,8 @@ func (b *BlugeReader) generateAggregations(
 			result[name] = aggregations.WeightedAvg(search.Field(agg.WeightedAvg.Value.Field), search.Field(agg.WeightedAvg.Weight.Field))
 		} else if agg.Cardinality != nil {
 			result[name] = aggregations.Cardinality(search.Field(agg.Cardinality.Field))
+		} else if agg.Percentiles != nil {
+			result[name] = custom_aggregations.NewPercentiles(search.Field(agg.Percentiles.Field), agg.Percentiles.Percents, agg.Percentiles.Compression)
 		}
 	}
 
@@ -556,6 +558,8 @@ func (b *BlugeReader) generateAggsResponse(
 			}
 			aggsResponse[name] = indexlib.AggsResponse{Buckets: aggsBuckets}
 		case search.MetricCalculator:
+			aggsResponse[name] = indexlib.AggsResponse{Value: value.Value()}
+		case *custom_aggregations.PercentilesCalculator:
 			aggsResponse[name] = indexlib.AggsResponse{Value: value.Value()}
 		case search.DurationCalculator:
 			aggsResponse[name] = indexlib.AggsResponse{Value: value.Duration().Milliseconds()}

--- a/internal/indexlib/query_request.go
+++ b/internal/indexlib/query_request.go
@@ -145,9 +145,16 @@ type Aggs struct {
 	Avg           *AggMetric
 	Cardinality   *AggMetric
 	WeightedAvg   *AggWeightedAvg
+	Percentiles   *AggPercentiles
 	DateHistogram *AggDateHistogram
 	Histogram     *AggHistogram
 	Aggs          map[string]Aggs
+}
+
+type AggPercentiles struct {
+	Field       string
+	Percents    []float64
+	Compression float64
 }
 
 type AggMetric struct {

--- a/internal/protocol/query_request.go
+++ b/internal/protocol/query_request.go
@@ -76,12 +76,21 @@ type Aggs struct {
 	Max           *AggMetric        `json:"max,omitempty"`
 	Avg           *AggMetric        `json:"avg,omitempty"`
 	Cardinality   *AggMetric        `json:"cardinality,omitempty"`
+	Percentiles   *AggPercentiles   `json:"percentiles,omitempty"`
 	WeightedAvg   *AggWeightedAvg   `json:"weighted_avg,omitempty"`
 	Aggs          map[string]Aggs   `json:"aggs,omitempty"`
 }
 
 type AggMetric struct {
 	Field string `json:"field"`
+}
+
+type AggPercentiles struct {
+	Field    string    `json:"field"` // only support numeric type
+	Percents []float64 `json:"percents"`
+	// Approximate algorithms must balance memory utilization with estimation accuracy. This balance
+	// can be controlled using a compression parameter
+	Compression float64 `json:"compression"`
 }
 
 type AggWeightedAvg struct {

--- a/internal/service/handler/query_handler_test.go
+++ b/internal/service/handler/query_handler_test.go
@@ -349,22 +349,46 @@ var cases = []QueryCase{
 	{
 		name: "histogram",
 		req: `
-				{
-				  "size": 0,
-				  "aggs": {
-					"histogram": {
-					  "histogram": {
-						"field": "stars",
-						"interval": 100,
-						"min_doc_count": 0,
-						"hard_bounds": {
-							"min": 100,
-							"max": 1000
-						}
+			{
+			  "size": 0,
+			  "aggs": {
+				"histogram": {
+				  "histogram": {
+					"field": "stars",
+					"interval": 100,
+					"min_doc_count": 0,
+					"hard_bounds": {
+						"min": 100,
+						"max": 1000
 					}
+				}
+			  }
+			}
+		  }
+		`,
+	},
+	{
+		name: "percentiles",
+		req: `
+			{
+			  "size": 0,
+			  "aggs": {
+				"percentiles_stars": {
+				  "percentiles": {
+					"field": "stars",
+					"percents": [
+					  1,
+					  5,
+					  25,
+					  50,
+					  75,
+					  95,
+					  99
+					]
 				  }
 				}
 			  }
+			}
 			`,
 	},
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #164

## Rationale for this change
 Support percentiles aggregation with [TDigest](https://github.com/caio/go-tdigest)

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
```
{
    "size": 0,
    "aggs": {
        "percentiles_stars": {
            "percentiles": {
                "field": "stars",
                "percents": [
                    1,
                    5,
                    25,
                    50,
                    75,
                    95,
                    99
                ]
            }
        }
    }
}
```
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
`internal/service/handler/query_handler_test.go`
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
