### PR TITLE
feat: improve range query

### DIFF
--- a/internal/common/utils/type_utils.go
+++ b/internal/common/utils/type_utils.go
@@ -3,7 +3,11 @@
 package utils
 
 import (
+	"fmt"
+	"strconv"
 	"time"
+
+	"github.com/tatris-io/tatris/internal/common/errs"
 
 	"github.com/jinzhu/now"
 )
@@ -65,5 +69,64 @@ func IsBool(value interface{}) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func ToFloat64(v interface{}) (float64, error) {
+	switch v := v.(type) {
+	case float64:
+		return v, nil
+	case uint64:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	case bool:
+		if v {
+			return 1, nil
+		}
+		return 0, nil
+	default:
+		return 0, &errs.UnsupportedError{Desc: "can not parse to float64", Value: v}
+	}
+}
+
+func ToString(v interface{}) string {
+	switch v := v.(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int:
+		return strconv.FormatInt(int64(v), 10)
+	case bool:
+		return strconv.FormatBool(v)
+	case time.Time:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", v)
 	}
 }

--- a/internal/indexlib/bluge/range_parser.go
+++ b/internal/indexlib/bluge/range_parser.go
@@ -4,61 +4,89 @@ package bluge
 
 import (
 	"math"
-	"strconv"
+	"time"
 
 	"github.com/blugelabs/bluge"
 	"github.com/tatris-io/tatris/internal/common/errs"
+	"github.com/tatris-io/tatris/internal/common/utils"
 	"github.com/tatris-io/tatris/internal/indexlib"
 )
 
-func RangeQueryParse(rangeQuery *indexlib.RangeQuery) (bluge.Query, error) {
+func ParseRangeQuery(rangeQuery *indexlib.RangeQuery) (bluge.Query, error) {
 	if len(rangeQuery.Range) <= 0 {
 		return nil, &errs.InvalidQueryError{Query: rangeQuery, Message: "invalid range"}
 	}
-	//numeric parse
-	field := ""
-	min := float64(math.MinInt64)
-	max := float64(math.MaxInt64)
 	containsMin := false
 	containsMax := false
+	for field, rangeVal := range rangeQuery.Range {
+		if utils.IsNumeric(rangeVal.GT) || utils.IsNumeric(rangeVal.GTE) ||
+			utils.IsNumeric(rangeVal.LT) ||
+			utils.IsNumeric(rangeVal.LTE) {
+			min := float64(math.MinInt64)
+			max := float64(math.MaxInt64)
+			if utils.IsNumeric(rangeVal.GT) {
+				min, _ = utils.ToFloat64(rangeVal.GT)
+			}
+			if utils.IsNumeric(rangeVal.GTE) {
+				min, _ = utils.ToFloat64(rangeVal.GTE)
+				containsMin = true
+			}
+			if utils.IsNumeric(rangeVal.LT) {
+				max, _ = utils.ToFloat64(rangeVal.LT)
+			}
+			if utils.IsNumeric(rangeVal.LTE) {
+				max, _ = utils.ToFloat64(rangeVal.LTE)
+				containsMax = true
+			}
+			return bluge.NewNumericRangeInclusiveQuery(min, max, containsMin, containsMax).
+				SetField(field), nil
 
-	for k, v := range rangeQuery.Range {
-		field = k
-		if v.GT != nil {
-			min, _ = toFloat64(v.GT)
-		} else if v.GTE != nil {
-			min, _ = toFloat64(v.GTE)
-			containsMin = true
 		}
-		if v.LT != nil {
-			max, _ = toFloat64(v.LT)
-		} else if v.LTE != nil {
-			max, _ = toFloat64(v.LTE)
-			containsMax = true
+		if utils.IsDateType(rangeVal.GT) || utils.IsDateType(rangeVal.GTE) ||
+			utils.IsDateType(rangeVal.LT) ||
+			utils.IsDateType(rangeVal.LTE) {
+			min := time.UnixMilli(0)
+			max := time.Now()
+			if utils.IsDateType(rangeVal.GT) {
+				min, _ = utils.ParseTime(rangeVal.GT)
+			}
+			if utils.IsDateType(rangeVal.GTE) {
+				min, _ = utils.ParseTime(rangeVal.GTE)
+				containsMin = true
+			}
+			if utils.IsDateType(rangeVal.LT) {
+				max, _ = utils.ParseTime(rangeVal.LT)
+			}
+			if utils.IsDateType(rangeVal.LTE) {
+				max, _ = utils.ParseTime(rangeVal.LTE)
+				containsMax = true
+			}
+			return bluge.NewDateRangeInclusiveQuery(min, max, containsMin, containsMax).
+					SetField(field),
+				nil
+		}
+		if utils.IsString(rangeVal.GT) || utils.IsString(rangeVal.GTE) ||
+			utils.IsString(rangeVal.LT) ||
+			utils.IsString(rangeVal.LTE) {
+			var min, max string
+			if utils.IsString(rangeVal.GT) {
+				min = utils.ToString(rangeVal.GT)
+			}
+			if utils.IsString(rangeVal.GTE) {
+				min = utils.ToString(rangeVal.GTE)
+				containsMin = true
+			}
+			if utils.IsString(rangeVal.LT) {
+				max = utils.ToString(rangeVal.LT)
+			}
+			if utils.IsString(rangeVal.LTE) {
+				max = utils.ToString(rangeVal.LTE)
+				containsMax = true
+			}
+			return bluge.NewTermRangeInclusiveQuery(min, max, containsMin, containsMax).
+					SetField(field),
+				nil
 		}
 	}
-	q := bluge.NewNumericRangeInclusiveQuery(min, max, containsMin, containsMax).SetField(field)
-	return q, nil
-}
-
-func toFloat64(v interface{}) (float64, error) {
-	switch v := v.(type) {
-	case float64:
-		return v, nil
-	case uint64:
-		return float64(v), nil
-	case int64:
-		return float64(v), nil
-	case int:
-		return float64(v), nil
-	case string:
-		return strconv.ParseFloat(v, 64)
-	case bool:
-		if v {
-			return 1, nil
-		}
-		return 0, nil
-	default:
-		return 0, &errs.UnsupportedError{Desc: "range type", Value: v}
-	}
+	return nil, &errs.InvalidQueryError{Message: "range query", Query: rangeQuery}
 }

--- a/internal/indexlib/bluge/reader.go
+++ b/internal/indexlib/bluge/reader.go
@@ -273,7 +273,7 @@ func (b *BlugeReader) generateQuery(query indexlib.QueryRequest) (bluge.Query, e
 		}
 		blugeQuery = q
 	case *indexlib.RangeQuery:
-		q, err := RangeQueryParse(query)
+		q, err := ParseRangeQuery(query)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/handler/query_handler_test.go
+++ b/internal/service/handler/query_handler_test.go
@@ -254,6 +254,21 @@ var cases = []QueryCase{
                  }`,
 	},
 	{
+		name: "range",
+		req: `
+		{
+		    "size": 20,
+		    "query": {
+		        "range": {
+		            "name": {
+		                "gte": "a",
+		                "lte": "b"
+		            }
+		        }
+		    }
+		}`,
+	},
+	{
 		name: "agg",
 		req: `
                  {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #89 

## Rationale for this change
Improved the implementation of range query, supporting `string` type in addition to the `date` type mentioned in the issue above.
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Tatris will refer to the `mappings` to parse the incoming `range` query, and build different bluge queries accordingly.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users can now pass in more types of range queries, including:

- `numeric types`: integer, long, short, byte, float, double.
- `string types`: keyword, constant_keyword, text, match_only_text.
- `bool types`: bool, boolean.
- `date types`: date.

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and unit tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
