### PR TITLE
fix: fix unexpected field type caused by dynamic_templates loss

### DIFF
--- a/internal/meta/metadata/index_manager.go
+++ b/internal/meta/metadata/index_manager.go
@@ -149,6 +149,23 @@ func BuildIndex(index *core.Index, template *protocol.IndexTemplate) {
 				if template.Template.Mappings.Dynamic != "" {
 					mappings.Dynamic = template.Template.Mappings.Dynamic
 				}
+				if len(template.Template.Mappings.DynamicTemplates) > 0 {
+					mappings.DynamicTemplates = make([]map[string]*protocol.DynamicTemplate, len(template.Template.Mappings.DynamicTemplates))
+					for i, dt := range template.Template.Mappings.DynamicTemplates {
+						mappings.DynamicTemplates[i] = make(map[string]*protocol.DynamicTemplate)
+						for k, v := range dt {
+							mappings.DynamicTemplates[i][k] = &protocol.DynamicTemplate{
+								Mapping:          &protocol.DynamicTemplateMapping{Type: v.Mapping.Type},
+								MatchMappingType: v.MatchMappingType,
+								MatchPattern:     v.MatchPattern,
+								Match:            v.Match,
+								Unmatch:          v.Unmatch,
+								PathMatch:        v.PathMatch,
+								PathUnmatch:      v.PathUnmatch,
+							}
+						}
+					}
+				}
 				for n, p := range template.Template.Mappings.Properties {
 					mappings.Properties[n] = &protocol.Property{Type: p.Type, Dynamic: p.Dynamic}
 				}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #174 

## Rationale for this change
To fix the problem described in the issue caused by `dynamic_templates` not taking effect.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
When an index template matches the index to be created, fill its `dynamic_templates` into the `mappings` of the target index to fix the problem that the expected field type mapping does not take effect.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users can now correctly specify the type of unknown fields via dynamic_templates.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
