### PR TITLE
feat: make the data path configurable

### DIFF
--- a/conf/server-conf.yml
+++ b/conf/server-conf.yml
@@ -1,3 +1,4 @@
+data_path: /home/tatris/data
 segment:
   mature_threshold: 20000
 wal:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,7 @@ RUN chown -R tatris:tatris /home/tatris
 
 COPY --from=build /go/bin /home/tatris/bin
 COPY bin/start-server.sh /home/tatris/bin
+COPY conf/*.yml /home/tatris/conf/
 
 USER tatris
 

--- a/internal/common/consts/path.go
+++ b/internal/common/consts/path.go
@@ -3,7 +3,8 @@
 package consts
 
 const (
-	DefaultDataPath = "/tmp/tatris/_data"
-	DefaultMetaPath = "/tmp/tatris/_meta"
-	DefaultWALPath  = "/tmp/tatris/_wal"
+	DefaultPath = "/tmp/tatris"
+	PathData    = "_data"
+	PathMeta    = "_meta"
+	PathWAL     = "_wal"
 )

--- a/internal/core/index.go
+++ b/internal/core/index.go
@@ -8,8 +8,9 @@ import (
 	"path"
 	"sync"
 
+	"github.com/tatris-io/tatris/internal/core/config"
+
 	"github.com/pkg/errors"
-	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/errs"
 	"github.com/tatris-io/tatris/internal/common/log/logger"
 	"github.com/tatris-io/tatris/internal/indexlib"
@@ -72,7 +73,7 @@ func (index *Index) GetReadersByTime(start, end int64) (indexlib.Reader, error) 
 		return nil, errs.ErrNoSegmentMatched
 	}
 	merged, err := MergeSegmentReader(&indexlib.BaseConfig{
-		DataPath: consts.DefaultDataPath,
+		DataPath: config.Cfg.GetDataPath(),
 	}, segments...)
 	if err != nil {
 		return nil, errors.Wrap(err, "fail to merge multiple segment readers")
@@ -104,6 +105,6 @@ func (index *Index) Close() error {
 		shard.Close()
 	}
 	// clear data
-	p := path.Join(consts.DefaultDataPath, index.Name)
+	p := path.Join(config.Cfg.GetDataPath(), index.Name)
 	return os.RemoveAll(p)
 }

--- a/internal/core/segment.go
+++ b/internal/core/segment.go
@@ -16,7 +16,6 @@ import (
 	"github.com/tatris-io/tatris/internal/common/log/logger"
 	"go.uber.org/zap"
 
-	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/indexlib"
 	"github.com/tatris-io/tatris/internal/indexlib/manage"
 )
@@ -79,7 +78,7 @@ func (segment *Segment) GetWriter() (indexlib.Writer, error) {
 func (segment *Segment) openWriter() (indexlib.Writer, error) {
 	// open a writer
 	config := &indexlib.BaseConfig{
-		DataPath: consts.DefaultDataPath,
+		DataPath: config.Cfg.GetDataPath(),
 	}
 	writer, err := manage.GetWriter(
 		config,
@@ -137,7 +136,7 @@ func (segment *Segment) GetReader() (indexlib.Reader, error) {
 	}
 
 	config := &indexlib.BaseConfig{
-		DataPath: consts.DefaultDataPath,
+		DataPath: config.Cfg.GetDataPath(),
 	}
 
 	// The segment is readonly, so we can cache the result and reuse it

--- a/internal/core/wal/wal.go
+++ b/internal/core/wal/wal.go
@@ -58,7 +58,7 @@ func OpenWAL(shard *core.Shard) (log.WalLog, error) {
 	defer utils.Timerf("open wal finish, name:%s", name)()
 
 	options := config.Cfg.Wal
-	p := path.Join(consts.DefaultWALPath, name)
+	p := path.Join(config.Cfg.GetWALPath(), name)
 	logger.Info("open wal", zap.String("name", name), zap.Any("options", options))
 	twalLog := &tidwall.TWalLog{}
 	twalOptions := &wal.Options{}
@@ -144,9 +144,9 @@ func ConsumeWALs() {
 					wallog.Close()
 					var p string
 					if errs.IsIndexNotFound(err) {
-						p = path.Join(consts.DefaultWALPath, i)
+						p = path.Join(config.Cfg.GetWALPath(), i)
 					} else {
-						p = path.Join(consts.DefaultWALPath, n)
+						p = path.Join(config.Cfg.GetWALPath(), n)
 					}
 					err = os.RemoveAll(p)
 					if err != nil {

--- a/internal/indexlib/indexlib_test/indexlib_test.go
+++ b/internal/indexlib/indexlib_test/indexlib_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tatris-io/tatris/internal/core/config"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/log/logger"
@@ -30,7 +32,7 @@ func TestIndexLib(t *testing.T) {
 
 	// test
 	t.Run("test_write", func(t *testing.T) {
-		if writer, err := manage.GetWriter(&indexlib.BaseConfig{DataPath: consts.DefaultDataPath}, *index.Mappings, index.Name, index.Name); err != nil {
+		if writer, err := manage.GetWriter(&indexlib.BaseConfig{DataPath: config.Cfg.GetDataPath()}, *index.Mappings, index.Name, index.Name); err != nil {
 			t.Fatalf("get writer error: %s", err.Error())
 		} else {
 			defer writer.Close()
@@ -55,7 +57,7 @@ func TestIndexLib(t *testing.T) {
 	t.Run("test_read", func(t *testing.T) {
 		reader, err := manage.GetReader(
 			&indexlib.BaseConfig{
-				DataPath: consts.DefaultDataPath,
+				DataPath: config.Cfg.GetDataPath(),
 			},
 			index.Name,
 		)

--- a/internal/meta/metadata/storage/boltdb/boltdb.go
+++ b/internal/meta/metadata/storage/boltdb/boltdb.go
@@ -8,11 +8,12 @@ import (
 	"os"
 	"path"
 
+	"github.com/tatris-io/tatris/internal/core/config"
+
 	"go.uber.org/zap"
 
 	"github.com/tatris-io/tatris/internal/common/utils"
 
-	"github.com/tatris-io/tatris/internal/common/consts"
 	"github.com/tatris-io/tatris/internal/common/log/logger"
 	"github.com/tatris-io/tatris/internal/meta/metadata/storage"
 	"go.etcd.io/bbolt"
@@ -23,7 +24,7 @@ type BoltMetaStore struct {
 }
 
 func Open() (storage.MetaStore, error) {
-	p := consts.DefaultMetaPath + ".bolt"
+	p := config.Cfg.GetMetaPath() + ".bolt"
 	logger.Info("open boltdb", zap.String("path", p))
 	d := path.Dir(p)
 	// mkdir

--- a/internal/query/query_doc.go
+++ b/internal/query/query_doc.go
@@ -44,7 +44,7 @@ func SearchDocs(
 		return &protocol.QueryResponse{Hits: protocol.Hits{Hits: []protocol.Hit{}}}, nil
 	}
 	reader, err := core.MergeSegmentReader(&indexlib.BaseConfig{
-		DataPath: consts.DefaultDataPath,
+		DataPath: config.Cfg.GetDataPath(),
 	}, allSegments...)
 	if err != nil {
 		return nil, err

--- a/supervisor/entrypoint.sh
+++ b/supervisor/entrypoint.sh
@@ -15,6 +15,6 @@ function fixAuth() {
   fi
 }
 
-fixAuth /home/tatris/logs
+fixAuth /home/tatris
 
 exec sudo -E /usr/bin/supervisord -n


### PR DESCRIPTION
## Which issue does this PR close?

Closes #180 

## Rationale for this change
This PR is to give users more flexibility in choosing where to store their data.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- The field `data_path` is added in [config.go](https://github.com/xiangwanpeng/tatris/blob/feat/data-path/internal/core/config/config.go) to specify the final storage location of the data.
- In the source code, `data_path` is set to `/tmp/tatris` by default for local debugging.
- In the configuration files, the `data_path` is set to `/home/tatris` by default, which is more likely to take effect in a formal startup mode based on `docker` or `k8s`.
- In addition to the above features, users can still customize their data storage paths by passing in configuration files,  please refer to [How to configure Tatris](https://github.com/tatris-io/tatris/blob/main/docs/user_guides/configure.md) for more information.


<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users can now customize the data storage path.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
