### PR TITLE
feat: improve metadata initialization

### DIFF
--- a/internal/meta/metadata/alias_manager.go
+++ b/internal/meta/metadata/alias_manager.go
@@ -94,7 +94,7 @@ func remove(terms []*protocol.AliasTerm, term *protocol.AliasTerm) []*protocol.A
 }
 
 func ListTerms() []*protocol.AliasTerm {
-	items := M().AliasTermsCache.Items()
+	items := Instance().AliasTermsCache.Items()
 	terms := make([]*protocol.AliasTerm, 0)
 	for _, item := range items {
 		terms = append(terms, item.Object.([]*protocol.AliasTerm)...)
@@ -104,7 +104,7 @@ func ListTerms() []*protocol.AliasTerm {
 
 func GetTermsByAlias(alias string) []*protocol.AliasTerm {
 	var terms []*protocol.AliasTerm
-	cached, found := M().AliasTermsCache.Get(alias)
+	cached, found := Instance().AliasTermsCache.Get(alias)
 	if found {
 		terms = cached.([]*protocol.AliasTerm)
 	}
@@ -113,7 +113,7 @@ func GetTermsByAlias(alias string) []*protocol.AliasTerm {
 
 func GetTermsByIndex(index string) []*protocol.AliasTerm {
 	terms := make([]*protocol.AliasTerm, 0)
-	cached, found := M().IndexTermsCache.Get(index)
+	cached, found := Instance().IndexTermsCache.Get(index)
 	if found {
 		terms = cached.([]*protocol.AliasTerm)
 	}
@@ -139,14 +139,14 @@ func saveAlias(
 	index string,
 	indexTerms []*protocol.AliasTerm,
 ) error {
-	M().AliasTermsCache.Set(alias, aliasTerms, cache.NoExpiration)
-	M().IndexTermsCache.Set(index, indexTerms, cache.NoExpiration)
+	Instance().AliasTermsCache.Set(alias, aliasTerms, cache.NoExpiration)
+	Instance().IndexTermsCache.Set(index, indexTerms, cache.NoExpiration)
 
 	indexTermsJSON, err := json.Marshal(indexTerms)
 	if err != nil {
 		return err
 	}
-	return M().MStore.Set(aliasPrefix(index), indexTermsJSON)
+	return Instance().MStore.Set(aliasPrefix(index), indexTermsJSON)
 }
 
 func aliasPrefix(name string) string {

--- a/internal/meta/metadata/index_manager.go
+++ b/internal/meta/metadata/index_manager.go
@@ -54,8 +54,8 @@ func SaveIndex(index *core.Index) error {
 	if err != nil {
 		return err
 	}
-	M().IndexCache.Set(index.Name, index, cache.NoExpiration)
-	return M().MStore.Set(indexPrefix(index.Name), json)
+	Instance().IndexCache.Set(index.Name, index, cache.NoExpiration)
+	return Instance().MStore.Set(indexPrefix(index.Name), json)
 }
 
 func GetShard(indexName string, shardID int) (*core.Shard, error) {
@@ -75,7 +75,7 @@ func GetShard(indexName string, shardID int) (*core.Shard, error) {
 
 func GetIndex(indexName string) (*core.Index, error) {
 	var index *core.Index
-	cachedIndex, found := M().IndexCache.Get(indexName)
+	cachedIndex, found := Instance().IndexCache.Get(indexName)
 	if found {
 		index = cachedIndex.(*core.Index)
 		return index, nil
@@ -89,7 +89,7 @@ func DeleteIndex(indexName string) error {
 		return err
 	}
 	// first set the cache disable, then all requests for this index will get a 404
-	M().IndexCache.Delete(indexName)
+	Instance().IndexCache.Delete(indexName)
 	// close the index and its components (shards, segments, wals ...)
 	err = index.Close()
 	if err != nil {
@@ -101,7 +101,7 @@ func DeleteIndex(indexName string) error {
 		return err
 	}
 	// remove the index from metastore
-	return M().MStore.Delete(indexPrefix(indexName))
+	return Instance().MStore.Delete(indexPrefix(indexName))
 }
 
 func BuildIndex(index *core.Index, template *protocol.IndexTemplate) {

--- a/internal/meta/metadata/index_template_manager.go
+++ b/internal/meta/metadata/index_template_manager.go
@@ -32,13 +32,13 @@ func SaveIndexTemplate(template *protocol.IndexTemplate) error {
 	if err != nil {
 		return err
 	}
-	M().TemplateCache.Set(template.Name, template, cache.NoExpiration)
-	return M().MStore.Set(indexTemplatePrefix(template.Name), json)
+	Instance().TemplateCache.Set(template.Name, template, cache.NoExpiration)
+	return Instance().MStore.Set(indexTemplatePrefix(template.Name), json)
 }
 
 func FindTemplates(indexName string) *protocol.IndexTemplate {
 	var template *protocol.IndexTemplate
-	for _, item := range M().TemplateCache.Items() {
+	for _, item := range Instance().TemplateCache.Items() {
 		t := item.Object.(*protocol.IndexTemplate)
 		for _, pattern := range t.IndexPatterns {
 			if wildcard.Match(pattern, indexName) {
@@ -54,7 +54,7 @@ func FindTemplates(indexName string) *protocol.IndexTemplate {
 
 func GetIndexTemplate(templateName string) (*protocol.IndexTemplate, error) {
 	var template *protocol.IndexTemplate
-	cachedTemplate, found := M().TemplateCache.Get(templateName)
+	cachedTemplate, found := Instance().TemplateCache.Get(templateName)
 	if found {
 		template = cachedTemplate.(*protocol.IndexTemplate)
 		return template, nil
@@ -63,8 +63,8 @@ func GetIndexTemplate(templateName string) (*protocol.IndexTemplate, error) {
 }
 
 func DeleteIndexTemplate(templateName string) error {
-	M().TemplateCache.Delete(templateName)
-	return M().MStore.Delete(indexTemplatePrefix(templateName))
+	Instance().TemplateCache.Delete(templateName)
+	return Instance().MStore.Delete(indexTemplatePrefix(templateName))
 }
 
 func FillTemplateAsDefault(template *protocol.IndexTemplate) {

--- a/internal/meta/metadata/metadata.go
+++ b/internal/meta/metadata/metadata.go
@@ -36,7 +36,8 @@ type Metadata struct {
 var metadata *Metadata
 var _once sync.Once
 
-func M() *Metadata {
+// Instance lazily initializes a Metadata singleton and returns it
+func Instance() *Metadata {
 	_once.Do(func() {
 		metadata = &Metadata{}
 		metadata.initMetadata()


### PR DESCRIPTION
## Which issue does this PR close?

Closes #161 

## Rationale for this change
This PR is to optimize the Tatris startup process: the server should initialize metadata when it is really needed, rather than doing it automatically in the init block.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Converge all meta information into struct `Metadata`, and implement lazy singleton initialization through `sync.Once`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
When users view the version or help information through the CLI, the console will no longer display logs related to metadata initialization.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
