### PR TITLE
feat(meta): constrained the naming of resources

### DIFF
--- a/internal/common/consts/punctuation.go
+++ b/internal/common/consts/punctuation.go
@@ -3,7 +3,9 @@
 package consts
 
 const (
+	Dot          = "."
 	Comma        = ","
 	Asterisk     = "*"
 	QuestionMark = "?"
+	Empty        = ""
 )

--- a/internal/common/consts/time.go
+++ b/internal/common/consts/time.go
@@ -1,0 +1,7 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package consts
+
+const (
+	TimeFmtWithoutSeparator = "20060102150405.999999999"
+)

--- a/internal/common/errs/error.go
+++ b/internal/common/errs/error.go
@@ -191,3 +191,17 @@ type InvalidBulkError struct {
 func (e *InvalidBulkError) Error() string {
 	return fmt.Sprintf("invalid bulk request: %s", e.Message)
 }
+
+type InvalidResourceNameError struct {
+	Name    string `json:"name"`
+	Message string `json:"message"`
+}
+
+func (e *InvalidResourceNameError) Error() string {
+	return fmt.Sprintf("invalid resource name: %s, %s", e.Name, e.Message)
+}
+
+func IsInvalidResourceNameError(err error) bool {
+	var invalidResourceNameErr *InvalidResourceNameError
+	return err != nil && errors.As(err, &invalidResourceNameErr)
+}

--- a/internal/common/utils/string_utils.go
+++ b/internal/common/utils/string_utils.go
@@ -3,8 +3,12 @@
 package utils
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
+
+	"github.com/tatris-io/tatris/internal/common/errs"
 
 	"github.com/tatris-io/tatris/internal/common/consts"
 
@@ -14,6 +18,13 @@ import (
 const (
 	MatchModeRegex    = "regex"
 	MatchModeWildcard = "wildcard"
+
+	MaxNameBytes = 255
+)
+
+var (
+	InvalidNameChars       = []rune{'\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',', '#', ':'}
+	InvalidNameBorderChars = []rune{'.', '_'}
 )
 
 func Match(pattern, str, mode string) bool {
@@ -34,4 +45,66 @@ func WildcardMatch(pattern, str string) bool {
 
 func ContainsWildcard(str string) bool {
 	return strings.Contains(str, consts.Asterisk) || strings.Contains(str, consts.QuestionMark)
+}
+
+// ValidateResourceName is used to detect whether the naming of various resources such as index,
+// alias, and template is legal. This refers to elasticsearch, but it may be stricter than it.
+func ValidateResourceName(name string) error {
+
+	if len(name) == 0 {
+		return &errs.InvalidResourceNameError{Name: name, Message: fmt.Sprintf("must not be empty")}
+	}
+
+	if name != strings.ToLower(name) {
+		return &errs.InvalidResourceNameError{Name: name, Message: fmt.Sprintf("must be lowercase")}
+	}
+
+	if validateNameContains(name) == false {
+		return &errs.InvalidResourceNameError{
+			Name: name,
+			Message: fmt.Sprintf(
+				"must not contain the following characters: %s",
+				strings.Join(strings.Split(string(InvalidNameChars), ""), ", "),
+			),
+		}
+	}
+
+	if validateNameBorder(name) == false {
+		return &errs.InvalidResourceNameError{
+			Name: name,
+			Message: fmt.Sprintf(
+				"must not start or end with the following characters: %s",
+				strings.Join(strings.Split(string(InvalidNameBorderChars), ""), ","),
+			),
+		}
+	}
+	runeCount := utf8.RuneCountInString(name)
+	if runeCount > MaxNameBytes {
+		return &errs.InvalidResourceNameError{
+			Name:    name,
+			Message: fmt.Sprintf("name is too long, (%d > %d)", runeCount, MaxNameBytes),
+		}
+	}
+	return nil
+}
+
+func validateNameContains(name string) bool {
+	for _, c := range name {
+		for _, invalidChar := range InvalidNameChars {
+			if c == invalidChar {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func validateNameBorder(name string) bool {
+	runes := []rune(name)
+	for _, invalidBorderChar := range InvalidNameBorderChars {
+		if runes[0] == invalidBorderChar || runes[len(runes)-1] == invalidBorderChar {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/common/utils/string_utils_test.go
+++ b/internal/common/utils/string_utils_test.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateIndexOrAliasName(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{
+			name:  "valid name",
+			input: "my_index123",
+			valid: true,
+		},
+		{
+			name:  "valid name with Chinese",
+			input: "我的索引",
+			valid: true,
+		},
+		{
+			name:  "invalid name with space",
+			input: "my index",
+			valid: false,
+		},
+		{
+			name:  "invalid name with special character",
+			input: "my_index*",
+			valid: false,
+		},
+		{
+			name:  "empty name",
+			input: "",
+			valid: false,
+		},
+		{
+			name:  "invalid name with dot at the beginning",
+			input: ".myindex",
+			valid: false,
+		},
+		{
+			name:  "invalid name with underscore at the end",
+			input: "myindex_",
+			valid: false,
+		},
+		{
+			name:  "invalid name with length exceeding limit",
+			input: "long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name_long_index_name",
+			valid: false,
+		},
+		{
+			name:  "invalid Chinese name with length exceeding limit",
+			input: "超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称超长的中文名称",
+			valid: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateResourceName(tc.input)
+			assert.Equal(t, tc.valid, err == nil)
+		})
+	}
+}

--- a/internal/core/core_test/index_test.go
+++ b/internal/core/core_test/index_test.go
@@ -3,7 +3,9 @@
 package core_test
 
 import (
+	"github.com/tatris-io/tatris/internal/common/consts"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,7 +24,13 @@ func TestIndex(t *testing.T) {
 
 	// prepare
 	start := time.Now()
-	index, docs, err := prepare.CreateIndexAndDocs(start.Format(time.RFC3339Nano))
+	index, docs, err := prepare.CreateIndexAndDocs(
+		strings.ReplaceAll(
+			start.Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		),
+	)
 	if err != nil {
 		t.Fatalf("prepare docs fail: %s", err.Error())
 	}
@@ -64,7 +72,13 @@ func TestIndex(t *testing.T) {
 func TestSegmentReader(t *testing.T) {
 	// prepare
 	start := time.Now()
-	index, _, err := prepare.CreateIndexAndDocs(start.Format(time.RFC3339Nano))
+	index, _, err := prepare.CreateIndexAndDocs(
+		strings.ReplaceAll(
+			start.Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		),
+	)
 	if err != nil {
 		t.Fatalf("prepare docs fail: %s", err.Error())
 	}

--- a/internal/core/wal/wal_test.go
+++ b/internal/core/wal/wal_test.go
@@ -3,8 +3,11 @@
 package wal_test
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/tatris-io/tatris/internal/common/consts"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tatris-io/tatris/internal/core"
@@ -15,7 +18,13 @@ import (
 )
 
 func TestWal(t *testing.T) {
-	index, err := prepare.CreateIndex(time.Now().Format(time.RFC3339Nano))
+	index, err := prepare.CreateIndex(
+		strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		),
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, index)
 

--- a/internal/indexlib/indexlib_test/indexlib_test.go
+++ b/internal/indexlib/indexlib_test/indexlib_test.go
@@ -5,6 +5,7 @@ package indexlib_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,7 +22,13 @@ import (
 
 func TestIndexLib(t *testing.T) {
 	// prepare
-	index, err := prepare.CreateIndex(time.Now().Format(time.RFC3339Nano))
+	index, err := prepare.CreateIndex(
+		strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		),
+	)
 	if err != nil {
 		t.Fatalf("prepare index fail: %s", err.Error())
 	}

--- a/internal/meta/metadata/alias_manager.go
+++ b/internal/meta/metadata/alias_manager.go
@@ -6,6 +6,8 @@ package metadata
 import (
 	"encoding/json"
 
+	"github.com/tatris-io/tatris/internal/common/errs"
+
 	"github.com/bobg/go-generics/set"
 	"github.com/tatris-io/tatris/internal/common/utils"
 
@@ -30,6 +32,17 @@ func AddAlias(aliasTerm *protocol.AliasTerm) error {
 
 	index := aliasTerm.Index
 	alias := aliasTerm.Alias
+
+	if err := utils.ValidateResourceName(alias); err != nil {
+		return err
+	}
+
+	if existIndex, _ := GetIndexExplicitly(alias); existIndex != nil {
+		return &errs.InvalidResourceNameError{
+			Name:    alias,
+			Message: "an index or data stream exists with the same name as the alias",
+		}
+	}
 
 	logger.Info(
 		"add alias",

--- a/internal/meta/metadata/index_manager.go
+++ b/internal/meta/metadata/index_manager.go
@@ -34,6 +34,12 @@ const (
 )
 
 func CreateIndex(index *core.Index) error {
+	if err := utils.ValidateResourceName(index.Name); err != nil {
+		return err
+	}
+	if existAliases := GetAliasTerms("", index.Name); len(existAliases) > 0 {
+		return &errs.InvalidResourceNameError{Name: index.Name, Message: "already exists as alias"}
+	}
 	template := FindTemplates(index.Name)
 	BuildIndex(index, template)
 	if template != nil && template.Template != nil && template.Template.Aliases != nil {

--- a/internal/meta/metadata/index_template_manager.go
+++ b/internal/meta/metadata/index_template_manager.go
@@ -20,6 +20,9 @@ import (
 )
 
 func CreateIndexTemplate(template *protocol.IndexTemplate) error {
+	if err := utils.ValidateResourceName(template.Name); err != nil {
+		return err
+	}
 	FillTemplateAsDefault(template)
 	if err := CheckTemplateValid(template); err != nil {
 		return err

--- a/internal/protocol/index_template.go
+++ b/internal/protocol/index_template.go
@@ -17,7 +17,7 @@ type IndexTemplateTerm struct {
 
 type IndexTemplate struct {
 	// Name of the index template.
-	Name string `json:"-"`
+	Name string `json:"name"`
 	// Priority to determine index template precedence when a new data stream or index is created.
 	// The index template with the highest priority is chosen. If no priority is specified the
 	// template is treated as though it is of priority 0 (the lowest priority).

--- a/internal/service/handler/alias_handler.go
+++ b/internal/service/handler/alias_handler.go
@@ -32,26 +32,24 @@ func ManageAliasHandler(c *gin.Context) {
 							BadRequest(c, "alias is required")
 						}
 						return
-					} else if exist, _ := metadata.GetIndexExplicitly(term.Alias); exist != nil {
-						BadRequest(c, fmt.Sprintf("Invalid alias name [%s]: an index or data stream exists with the same name as the alias", term.Alias))
-						return
-					} else {
-						// TODO: check the legality of the alias name,
-						// for example, it cannot contain *,?, etc.
-						if strings.EqualFold(name, "add") {
-							if err := metadata.AddAlias(term); err != nil {
+					}
+					if strings.EqualFold(name, "add") {
+						if err := metadata.AddAlias(term); err != nil {
+							if errs.IsInvalidResourceNameError(err) {
+								BadRequest(c, err.Error())
+							} else {
 								InternalServerError(c, err.Error())
-								return
 							}
-						} else if strings.EqualFold(name, "remove") {
-							if err := metadata.RemoveAlias(term); err != nil {
-								InternalServerError(c, err.Error())
-								return
-							}
-						} else {
-							BadRequest(c, fmt.Sprintf("[alias_action] unknown field [%s]", name))
 							return
 						}
+					} else if strings.EqualFold(name, "remove") {
+						if err := metadata.RemoveAlias(term); err != nil {
+							InternalServerError(c, err.Error())
+							return
+						}
+					} else {
+						BadRequest(c, fmt.Sprintf("[alias_action] unknown field [%s]", name))
+						return
 					}
 				}
 			}

--- a/internal/service/handler/alias_handler_test.go
+++ b/internal/service/handler/alias_handler_test.go
@@ -10,8 +10,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/tatris-io/tatris/internal/common/consts"
 
 	"github.com/bobg/go-generics/set"
 
@@ -31,7 +34,11 @@ func TestAliasHandler(t *testing.T) {
 	count := 10
 	versions := make([]string, count)
 	for i := 0; i < count; i++ {
-		versions[i] = time.Now().Format(time.RFC3339Nano)
+		versions[i] = strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		)
 		time.Sleep(time.Nanosecond * 1000)
 	}
 	indexes := make([]*core.Index, count)

--- a/internal/service/handler/bulk_handler_test.go
+++ b/internal/service/handler/bulk_handler_test.go
@@ -10,8 +10,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/tatris-io/tatris/internal/common/consts"
 
 	"github.com/tatris-io/tatris/internal/core"
 	"github.com/tatris-io/tatris/internal/protocol"
@@ -26,7 +29,11 @@ func TestBulkHandler(t *testing.T) {
 	count := 5
 	versions := make([]string, count)
 	for i := 0; i < count; i++ {
-		versions[i] = time.Now().Format(time.RFC3339Nano)
+		versions[i] = strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		)
 		time.Sleep(time.Nanosecond * 1000)
 	}
 	indexes := make([]*core.Index, count)

--- a/internal/service/handler/index_handler.go
+++ b/internal/service/handler/index_handler.go
@@ -4,9 +4,8 @@
 package handler
 
 import (
-	"github.com/tatris-io/tatris/internal/common/errs"
-
 	"github.com/gin-gonic/gin"
+	"github.com/tatris-io/tatris/internal/common/errs"
 	"github.com/tatris-io/tatris/internal/core"
 	"github.com/tatris-io/tatris/internal/meta/metadata"
 	"github.com/tatris-io/tatris/internal/protocol"
@@ -23,7 +22,11 @@ func CreateIndexHandler(c *gin.Context) {
 		if err := c.ShouldBind(&index); err != nil {
 			BadRequest(c, err.Error())
 		} else if err := metadata.CreateIndex(&core.Index{Index: &index}); err != nil {
-			InternalServerError(c, err.Error())
+			if errs.IsInvalidResourceNameError(err) {
+				BadRequest(c, err.Error())
+			} else {
+				InternalServerError(c, err.Error())
+			}
 		} else {
 			OK(c, protocol.CreateIndexResponse{
 				Response:           &protocol.Response{Acknowledged: true},

--- a/internal/service/handler/index_handler_test.go
+++ b/internal/service/handler/index_handler_test.go
@@ -10,8 +10,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/tatris-io/tatris/internal/common/consts"
 
 	"github.com/tatris-io/tatris/internal/core"
 
@@ -23,7 +26,13 @@ import (
 
 func TestIndexHandler(t *testing.T) {
 
-	index, err := prepare.GetIndex(time.Now().Format(time.RFC3339Nano))
+	index, err := prepare.GetIndex(
+		strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		),
+	)
 	if err != nil {
 		t.Fatalf("prepare index and docs fail: %s", err.Error())
 	}

--- a/internal/service/handler/index_template_handler.go
+++ b/internal/service/handler/index_template_handler.go
@@ -4,9 +4,8 @@
 package handler
 
 import (
-	"github.com/tatris-io/tatris/internal/common/errs"
-
 	"github.com/gin-gonic/gin"
+	"github.com/tatris-io/tatris/internal/common/errs"
 	"github.com/tatris-io/tatris/internal/meta/metadata"
 	"github.com/tatris-io/tatris/internal/protocol"
 )

--- a/internal/service/handler/index_template_handler_test.go
+++ b/internal/service/handler/index_template_handler_test.go
@@ -10,8 +10,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/tatris-io/tatris/internal/common/consts"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +24,13 @@ import (
 
 func TestIndexTemplateHandler(t *testing.T) {
 
-	template, err := prepare.GetIndexTemplate(time.Now().Format(time.RFC3339Nano))
+	template, err := prepare.GetIndexTemplate(
+		strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		),
+	)
 	if err != nil {
 		t.Fatalf("prepare template fail: %s", err.Error())
 	}

--- a/internal/service/handler/ingest_handler_test.go
+++ b/internal/service/handler/ingest_handler_test.go
@@ -9,8 +9,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/tatris-io/tatris/internal/common/consts"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -19,7 +22,13 @@ import (
 
 func TestIngestHandler(t *testing.T) {
 	// prepare
-	index, err := prepare.CreateIndex(time.Now().Format(time.RFC3339Nano))
+	index, err := prepare.CreateIndex(
+		strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		),
+	)
 	if err != nil {
 		t.Fatalf("prepare index fail: %s", err.Error())
 	}

--- a/internal/service/handler/query_handler_test.go
+++ b/internal/service/handler/query_handler_test.go
@@ -28,7 +28,13 @@ import (
 func TestQuerySingleIndex(t *testing.T) {
 
 	// prepare
-	index, _, err := prepare.CreateIndexAndDocs(time.Now().Format(time.RFC3339Nano))
+	index, _, err := prepare.CreateIndexAndDocs(
+		strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		),
+	)
 	if err != nil {
 		t.Fatalf("prepare index and docs fail: %s", err.Error())
 	}
@@ -68,7 +74,11 @@ func TestQueryMultipleIndexes(t *testing.T) {
 	count := 5
 	versions := make([]string, count)
 	for i := 0; i < count; i++ {
-		versions[i] = time.Now().Format(time.RFC3339Nano)
+		versions[i] = strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		)
 		time.Sleep(time.Nanosecond * 1000)
 	}
 	indexes := make([]*core.Index, count)
@@ -116,7 +126,11 @@ func TestAliasQuery(t *testing.T) {
 	count := 5
 	versions := make([]string, count)
 	for i := 0; i < count; i++ {
-		versions[i] = time.Now().Format(time.RFC3339Nano)
+		versions[i] = strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		)
 		time.Sleep(time.Nanosecond * 1000)
 	}
 	indexes := make([]*core.Index, count)
@@ -211,7 +225,11 @@ func TestWildcardQuery(t *testing.T) {
 	count := 5
 	versions := make([]string, count)
 	for i := 0; i < count; i++ {
-		versions[i] = time.Now().Format(time.RFC3339Nano)
+		versions[i] = strings.ReplaceAll(
+			time.Now().Format(consts.TimeFmtWithoutSeparator),
+			consts.Dot,
+			consts.Empty,
+		)
 		time.Sleep(time.Nanosecond * 1000)
 	}
 	indexes := make([]*core.Index, count)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #194 

## Rationale for this change
This PR is to add constraints to the naming of various resources in Tatris to avoid unexpected confusion or errors.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Name verification is added to the creation of all resources. The verification is completed by the function `ValidateResourceName` of `string_utils.go`, which mainly includes the validity check at the string level, such as lowercase constraints, length constraints, special characters such as `*` cannot be included, etc.
- In addition to the above, there is also resource name conflict checking. For example, indexes and aliases cannot have the same name.
- Some previous unit tests were adjusted after naming constraints were added, because they created temporary resources that contained illegal characters such as upper case letters or `:`.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
From now on users will face some constraints when defining resources.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
The new string_utils_test.go is used to test named constraints. CI and regress tests also passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
