### PR TITLE
fix: fix marshal error of QueryRequest

### DIFF
--- a/internal/protocol/marshal.go
+++ b/internal/protocol/marshal.go
@@ -129,24 +129,24 @@ func (r *RangeVal) UnmarshalJSON(data []byte) error {
 	// {gt, gte, lt, lte} OR
 	// {from, include_lower, to, include_upper}.
 	// This is for compatibility with elasticsearch's query protocol.
-	if r.Lte == nil && r.Lt == nil && r.Gte == nil && r.Gt == nil {
+	if tmp.Lte == nil && tmp.Lt == nil && tmp.Gte == nil && tmp.Gt == nil {
 		result := gjson.ParseBytes(data)
 		from := result.Get("from")
 		if from.Exists() {
 			includeLower := result.Get("include_lower")
 			if includeLower.Exists() && includeLower.Bool() {
-				r.Gte = from.Value()
+				tmp.Gte = from.Value()
 			} else {
-				r.Gt = from.Value()
+				tmp.Gt = from.Value()
 			}
 		}
 		to := result.Get("to")
 		if to.Exists() {
 			includeUpper := result.Get("include_upper")
 			if includeUpper.Exists() && includeUpper.Bool() {
-				r.Lte = to.Value()
+				tmp.Lte = to.Value()
 			} else {
-				r.Lt = to.Value()
+				tmp.Lt = to.Value()
 			}
 		}
 	}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
This PR is to fix query exceptions caused by some problems in the custom marshal.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Perform explicit initialization of custom temporary struct instances and some nested members in unmarshal functions to avoid `NPE`.
- When assigning old values such as `from` in the range query to new values such as `gt`, directly obtain its `value()` instead of executing unmarshal by mistake.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users can now correctly execute queries with nested aggregates.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
