### PR TITLE
feat: execute term/terms query on numeric field with range query

### DIFF
--- a/internal/query/query_doc.go
+++ b/internal/query/query_doc.go
@@ -49,7 +49,7 @@ func SearchDocs(
 	}
 	if len(allSegments) == 0 {
 		// no match any segments, returns an empty response
-		return emptyResponse(), nil
+		return emptyResult(), nil
 	}
 	reader, err := core.MergeSegmentReader(&indexlib.BaseConfig{
 		DataPath: config.Cfg.GetDataPath(),
@@ -68,7 +68,7 @@ func SearchDocs(
 		return nil, err
 	}
 	if libRequest == nil {
-		return emptyResponse(), nil
+		return emptyResult(), nil
 	}
 
 	var aggsNamePrefixDict map[string]string
@@ -133,7 +133,7 @@ func SearchDocs(
 	return &protocol.QueryResponse{Hits: hits, Aggregations: aggregations}, nil
 }
 
-func emptyResponse() *protocol.QueryResponse {
+func emptyResult() *protocol.QueryResponse {
 	return &protocol.QueryResponse{
 		Hits: protocol.Hits{
 			Hits:  []protocol.Hit{},


### PR DESCRIPTION
## Which issue does this PR close?

Closes #205 

## Rationale for this change
To make Tatris correctly respond to `term/terms` queries on numeric fields.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
The functions `transformTerm` and `transformTerms` in `query_doc.go` are rewritten, and they determine and generate `TermQuery`, `RangeQuery` or `BoolQuery` according to the type of term value passed in.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users can now perform `term/terms` queries on numeric fields.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
