### PR TITLE
fix: unmarshal query request with default values

### DIFF
--- a/internal/protocol/marshal.go
+++ b/internal/protocol/marshal.go
@@ -4,6 +4,7 @@ package protocol
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"github.com/tidwall/gjson"
 )
@@ -53,13 +54,27 @@ func (q *QueryRequest) UnmarshalJSON(data []byte) error {
 			err = json.Unmarshal([]byte(aggregations.Raw), &tmp.Aggs)
 		}
 	}
-	q.Index = tmp.Index
-	q.Query = tmp.Query
-	q.Aggs = tmp.Aggs
-	q.Sort = tmp.Sort
-	q.Size = tmp.Size
-	q.From = tmp.From
-	q.TypedKeys = tmp.TypedKeys
+	if !reflect.ValueOf(tmp.Index).IsZero() {
+		q.Index = tmp.Index
+	}
+	if !reflect.ValueOf(tmp.Query).IsZero() {
+		q.Query = tmp.Query
+	}
+	if !reflect.ValueOf(tmp.Aggs).IsZero() {
+		q.Aggs = tmp.Aggs
+	}
+	if !reflect.ValueOf(tmp.Sort).IsZero() {
+		q.Sort = tmp.Sort
+	}
+	if !reflect.ValueOf(tmp.Size).IsZero() {
+		q.Size = tmp.Size
+	}
+	if !reflect.ValueOf(tmp.From).IsZero() {
+		q.From = tmp.From
+	}
+	if !reflect.ValueOf(tmp.TypedKeys).IsZero() {
+		q.TypedKeys = tmp.TypedKeys
+	}
 	return err
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
This is to fix the exception brought by the previous pull request: the custom unmarshal on `QueryRequest` overwhelms the default value passed in from the upstream.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
When doing unmarshal on QueryRequest, it will first judge whether the parsed field is zero value and only do the assignment when `reflect.ValueOf(value).IsZero() == false`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Almost none.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
