### PR TITLE
feat: log directory

### DIFF
--- a/internal/indexlib/bluge/config/bluge_config.go
+++ b/internal/indexlib/bluge/config/bluge_config.go
@@ -6,6 +6,8 @@ package config
 import (
 	"path"
 
+	"github.com/tatris-io/tatris/internal/indexlib/bluge/directory/fs"
+
 	"github.com/tatris-io/tatris/internal/indexlib/bluge/directory/oss"
 
 	"github.com/blugelabs/bluge"
@@ -13,7 +15,9 @@ import (
 )
 
 func GetFSConfig(filepath string, filename string) bluge.Config {
-	return bluge.DefaultConfig(path.Join(filepath, filename))
+	return bluge.DefaultConfigWithDirectory(func() index.Directory {
+		return fs.NewFsDirectory(path.Join(filepath, filename))
+	})
 }
 
 func GetOSSConfig(endpoint, bucket, accessKeyID, secretAccessKey, filename string) bluge.Config {

--- a/internal/indexlib/bluge/directory/fs/directory_fs.go
+++ b/internal/indexlib/bluge/directory/fs/directory_fs.go
@@ -92,7 +92,7 @@ func (d *FsDirectory) Stats() (numFilesOnDisk, numBytesUsedDisk uint64) {
 
 func (d *FsDirectory) Sync() error {
 	defer utils.Timerf(
-		"[directory] method:sync, type:fs, path:%s, filename:%s",
+		"[directory] method:sync, type:fs, path:%s",
 		d.path,
 	)()
 	return d.dir.Sync()

--- a/internal/indexlib/bluge/directory/fs/directory_fs.go
+++ b/internal/indexlib/bluge/directory/fs/directory_fs.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+// Package fs is just a simple encapsulation of index.NewFileSystemDirectory for logging time cost.
+package fs
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/blugelabs/bluge/index"
+	segment "github.com/blugelabs/bluge_segment_api"
+	"github.com/tatris-io/tatris/internal/common/utils"
+)
+
+type FsDirectory struct {
+	path string
+	dir  *index.FileSystemDirectory
+}
+
+func NewFsDirectory(path string) *FsDirectory {
+	return &FsDirectory{
+		path: path,
+		dir:  index.NewFileSystemDirectory(path),
+	}
+}
+
+func (d *FsDirectory) Setup(readOnly bool) error {
+	defer utils.Timerf(
+		"[directory] method:setup, type:fs, path:%s, readOnly:%t",
+		d.path,
+		readOnly,
+	)()
+	return d.dir.Setup(readOnly)
+}
+
+func (d *FsDirectory) List(kind string) ([]uint64, error) {
+	defer utils.Timerf(
+		"[directory] method:list, type:fs, path:%s, kind:%s",
+		d.path,
+		kind,
+	)()
+	return d.dir.List(kind)
+}
+
+func (d *FsDirectory) Persist(
+	kind string,
+	id uint64,
+	w index.WriterTo,
+	closeCh chan struct{},
+) error {
+	defer utils.Timerf(
+		"[directory] method:persist, type:fs, path:%s, filename:%s",
+		d.path,
+		d.fileName(kind, id),
+	)()
+	return d.dir.Persist(kind, id, w, closeCh)
+}
+
+func (d *FsDirectory) Load(kind string, id uint64) (*segment.Data, io.Closer, error) {
+	defer utils.Timerf(
+		"[directory] method:load, type:fs, path:%s, filename:%s",
+		d.path,
+		d.fileName(kind, id),
+	)()
+	return d.dir.Load(kind, id)
+}
+
+func (d *FsDirectory) Remove(kind string, id uint64) error {
+	defer utils.Timerf(
+		"[directory] method:remove, type:fs, path:%s, filename:%s",
+		d.path,
+		d.fileName(kind, id),
+	)()
+	return d.dir.Remove(kind, id)
+}
+
+func (d *FsDirectory) Lock() error {
+	return d.dir.Lock()
+}
+
+func (d *FsDirectory) Unlock() error {
+	return d.dir.Unlock()
+}
+
+func (d *FsDirectory) Stats() (numFilesOnDisk, numBytesUsedDisk uint64) {
+	defer utils.Timerf(
+		"[directory] method:stats, type:fs, path:%s",
+		d.path,
+	)()
+	return d.dir.Stats()
+}
+
+func (d *FsDirectory) Sync() error {
+	defer utils.Timerf(
+		"[directory] method:sync, type:fs, path:%s, filename:%s",
+		d.path,
+	)()
+	return d.dir.Sync()
+}
+
+func (d *FsDirectory) fileName(kind string, id uint64) string {
+	return fmt.Sprintf("%012x", id) + kind
+}

--- a/internal/indexlib/bluge/directory/oss/directory_oss.go
+++ b/internal/indexlib/bluge/directory/oss/directory_oss.go
@@ -45,7 +45,7 @@ func NewOssDirectory(endpoint, bucket, accessKeyID, secretAccessKey, index strin
 
 func (d *OssDirectory) Setup(readOnly bool) error {
 	defer utils.Timerf(
-		"oss dir setup finish, bucket:%s, index:%s, readOnly:%t",
+		"[directory] method:setup, type:oss, bucket:%s, index:%s, readOnly:%t",
 		d.bucket,
 		d.index,
 		readOnly,
@@ -66,7 +66,7 @@ func (d *OssDirectory) Setup(readOnly bool) error {
 func (d *OssDirectory) List(kind string) ([]uint64, error) {
 
 	defer utils.Timerf(
-		"oss dir list finish, bucket:%s, index:%s, kind:%s",
+		"[directory] method:list, type:oss, bucket:%s, index:%s, kind:%s",
 		d.bucket,
 		d.index,
 		kind,
@@ -89,7 +89,7 @@ func (d *OssDirectory) List(kind string) ([]uint64, error) {
 		epoch, err := strconv.ParseUint(base[:len(base)-len(kind)], 16, 64)
 		if err != nil {
 			logger.Error(
-				"oss dir parse object fail",
+				"oss list parse object fail",
 				zap.String("index", d.index),
 				zap.String("bucket", d.bucket),
 				zap.String("key", dirEntry.Key),
@@ -114,7 +114,7 @@ func (d *OssDirectory) Persist(
 
 	filename := d.fileName(kind, id)
 	defer utils.Timerf(
-		"oss dir persist finish, bucket:%s, index:%s, filename:%s",
+		"[directory] method:persist, type:oss, bucket:%s, index:%s, filename:%s",
 		d.bucket,
 		d.index,
 		filename,
@@ -127,7 +127,7 @@ func (d *OssDirectory) Persist(
 	_, err := w.WriteTo(&buf, closeCh)
 	if err != nil {
 		logger.Error(
-			"oss dir write buffer fail",
+			"oss persist write buffer fail",
 			zap.String("index", d.index),
 			zap.String("bucket", d.bucket),
 			zap.String("filename", filename),
@@ -147,7 +147,7 @@ func (d *OssDirectory) Load(kind string, id uint64) (*segment.Data, io.Closer, e
 
 	filename := d.fileName(kind, id)
 	defer utils.Timerf(
-		"oss dir load finish, bucket:%s, index:%s, filename:%s",
+		"[directory] method:load, type:oss, bucket:%s, index:%s, filename:%s",
 		d.bucket,
 		d.index,
 		filename,
@@ -165,7 +165,7 @@ func (d *OssDirectory) Load(kind string, id uint64) (*segment.Data, io.Closer, e
 		err := object.Close()
 		if err != nil {
 			logger.Error(
-				"oss dir close object fail",
+				"oss load close object fail",
 				zap.String("index", d.index),
 				zap.String("bucket", d.bucket),
 				zap.String("path", path),
@@ -184,7 +184,7 @@ func (d *OssDirectory) Remove(kind string, id uint64) error {
 
 	filename := d.fileName(kind, id)
 	defer utils.Timerf(
-		"oss dir remove finish, bucket:%s, index:%s, filename:%s",
+		"[directory] method:remove, type:oss, bucket:%s, index:%s, filename:%s",
 		d.bucket,
 		d.index,
 		filename,
@@ -217,7 +217,11 @@ func (d *OssDirectory) Unlock() error {
 
 func (d *OssDirectory) Stats() (numFilesOnDisk, numBytesUsedDisk uint64) {
 
-	defer utils.Timerf("oss dir stats finish, bucket:%s, index:%s", d.bucket, d.index)()
+	defer utils.Timerf(
+		"[directory] method:stats, type:oss, bucket:%s, index:%s",
+		d.bucket,
+		d.index,
+	)()
 
 	d.lock.RLock()
 	defer d.lock.RUnlock()
@@ -236,6 +240,11 @@ func (d *OssDirectory) Stats() (numFilesOnDisk, numBytesUsedDisk uint64) {
 }
 
 func (d *OssDirectory) Sync() error {
+	defer utils.Timerf(
+		"[directory] method:sync, type:oss, bucket:%s, index:%s",
+		d.bucket,
+		d.index,
+	)()
 	return nil
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
This PR records the operation time cost at the `directory` level to compare different storage media's read and write performance.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

1. `FileSystemDirectory` default integrated by Bluge is encapsulated as `FsDirectory` in Tatris.
2. All directory implementations of Tatris log operation count and time costs in a consistent format.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
