### PR TITLE
refactor: speed up docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ endif
 ifdef TAG
 DOCKER_BUILD_ARGS := -t $(TAG)  $(DOCKER_BUILD_ARGS)
 endif
+ifdef GOPROXY
+DOCKER_BUILD_ARGS := --build-arg GOPROXY=$(GOPROXY) $(DOCKER_BUILD_ARGS)
+endif
 
 check: install-tools
 	@ echo "do checks ..."

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,14 @@ FROM --platform=$TARGETPLATFORM golang:1.19 AS build
 ARG TARGETPLATFORM
 ARG GOLANG_LDFLAGS
 
+ARG GOPROXY=direct
+# You can use GOPROXY to speed up building.
+# ARG GOPROXY=https://...,direct
+
+# use docker cache to speed up building
 RUN --mount=target=/go/src,type=bind \
+  --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/root/go/pkg \
   echo "building for $TARGETPLATFORM" && \
   cd /go/src && \
   go build -ldflags="$GOLANG_LDFLAGS" -o /go/bin/tatris-server ./cmd/server/...

--- a/docs/dev_guides/build.md
+++ b/docs/dev_guides/build.md
@@ -47,5 +47,10 @@ A more practical example:
 make docker-image TAG=tatris:0.1.0 TARGETPLATFORM=linux/amd64
 ```
 
+Users in China can use GOPROXY to speed up building:
+```shell
+GOPROXY=https://goproxy.cn,direct make docker-image
+```
+
 ## Configure and launch Tatris
 Get the details in [configuring guide](/docs/user_guides/configure.md)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
Speed up docker build.

It takes about 10s to build docker image in my Linux when use proper GOPROXY and cache hit.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Supports GOPROXY when building image
- Enable docker cache when building image

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
