### PR TITLE
feat: cluster status

### DIFF
--- a/internal/common/consts/status.go
+++ b/internal/common/consts/status.go
@@ -2,8 +2,14 @@
 
 package consts
 
+// The index level status is controlled by the worst shard status. The cluster status is controlled
+// by the worst index status.
+// On the shard level:
 const (
-	StatusGreen  = "green"
+	// StatusGreen means that all shards are allocated.
+	StatusGreen = "green"
+	// StatusYellow means that the primary shard is allocated but replicas are not.
 	StatusYellow = "yellow"
-	StatusRed    = "red"
+	// StatusRed indicates that the specific shard is not allocated in the cluster.
+	StatusRed = "red"
 )

--- a/internal/common/consts/status.go
+++ b/internal/common/consts/status.go
@@ -1,0 +1,9 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package consts
+
+const (
+	StatusGreen  = "green"
+	StatusYellow = "yellow"
+	StatusRed    = "red"
+)

--- a/internal/protocol/cluster.go
+++ b/internal/protocol/cluster.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package protocol
+
+type ClusterStatus struct {
+	ClusterName                 string  `json:"cluster_name"`
+	Status                      string  `json:"status"`
+	TimedOut                    bool    `json:"timed_out"`
+	NumberOfNodes               int     `json:"number_of_nodes"`
+	NumberOfDataNodes           int     `json:"number_of_data_nodes"`
+	ActivePrimaryShards         int     `json:"active_primary_shards"`
+	ActiveShards                int     `json:"active_shards"`
+	RelocationShards            int     `json:"relocating_shards"`
+	InitializingShards          int     `json:"initializing_shards"`
+	UnassignedShards            int     `json:"unassigned_shards"`
+	DelayedUnassignedShards     int     `json:"delayed_unassigned_shards"`
+	NumberOfPendingTasks        int     `json:"number_of_pending_tasks"`
+	NumberOfInFlightFetch       int     `json:"number_of_in_flight_fetch"`
+	TaskMaxWaitingInQueueMills  int64   `json:"task_max_waiting_in_queue_millis"`
+	ActiveShardsPercentAsNumber float64 `json:"active_shards_percent_as_number"`
+}

--- a/internal/service/handler/cluster_handler.go
+++ b/internal/service/handler/cluster_handler.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
+// Package handler is about how to handle HTTP requests for meta
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/tatris-io/tatris/internal/common/consts"
+	"github.com/tatris-io/tatris/internal/protocol"
+)
+
+// ClusterStatusHandler is used to view the status of the cluster.
+// Right now this is a pseudo-implementation that the started cluster is always considered healthy until we support cluster mode.
+func ClusterStatusHandler(c *gin.Context) {
+	OK(c, protocol.ClusterStatus{
+		ClusterName:                 "docker-cluster",
+		Status:                      consts.StatusGreen,
+		TimedOut:                    false,
+		NumberOfNodes:               1,
+		NumberOfDataNodes:           1,
+		ActivePrimaryShards:         1,
+		ActiveShards:                1,
+		RelocationShards:            0,
+		InitializingShards:          0,
+		UnassignedShards:            0,
+		DelayedUnassignedShards:     0,
+		NumberOfPendingTasks:        0,
+		NumberOfInFlightFetch:       0,
+		TaskMaxWaitingInQueueMills:  0,
+		ActiveShardsPercentAsNumber: 100,
+	})
+}

--- a/internal/service/handler/cluster_handler.go
+++ b/internal/service/handler/cluster_handler.go
@@ -10,7 +10,8 @@ import (
 )
 
 // ClusterStatusHandler is used to view the status of the cluster.
-// Right now this is a pseudo-implementation that the started cluster is always considered healthy until we support cluster mode.
+// Right now this is a pseudo-implementation that the started cluster is always considered healthy
+// until we support cluster mode.
 func ClusterStatusHandler(c *gin.Context) {
 	OK(c, protocol.ClusterStatus{
 		ClusterName:                 "docker-cluster",

--- a/internal/service/handler/cluster_handler_test.go
+++ b/internal/service/handler/cluster_handler_test.go
@@ -1,0 +1,37 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/tatris-io/tatris/internal/protocol"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/tatris-io/tatris/internal/common/consts"
+)
+
+func TestClusterStatus(t *testing.T) {
+
+	t.Run("cluster_status", func(t *testing.T) {
+		gin.SetMode(gin.ReleaseMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		req := &http.Request{
+			URL:    &url.URL{},
+			Header: make(http.Header),
+		}
+		c.Request = req
+		c.Params = gin.Params{}
+		ClusterStatusHandler(c)
+		assert.Equal(t, http.StatusOK, w.Code)
+		clusterStatus := protocol.ClusterStatus{}
+		json.Unmarshal(w.Body.Bytes(), &clusterStatus)
+		assert.Equal(t, consts.StatusGreen, clusterStatus.Status)
+	})
+}

--- a/internal/service/router.go
+++ b/internal/service/router.go
@@ -83,6 +83,8 @@ func registerQuery(group *gin.RouterGroup) {
 func registerMeta(group *gin.RouterGroup) {
 	logger.Info("meta APIs registering")
 
+	group.GET("/_cluster/health", handler.ClusterStatusHandler)
+
 	group.PUT("/:index", handler.CreateIndexHandler)
 	group.POST("/:index", handler.CreateIndexHandler)
 	group.GET("/:index", handler.GetIndexHandler)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #195 

## Rationale for this change
This PR is to support viewing the status of the Tatris cluster.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
`ClusterHandler` is introduced.
However, this handler will be a pseudo-implementation (started clusters are always considered healthy) until we actually support cluster mode.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users can now get real-time cluster status via `GET /_cluster/health`. 
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
UT in `cluster_handler_test.go` passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
