### PR TITLE
refactor: OSS use local file cache

### DIFF
--- a/conf/server-conf.yml
+++ b/conf/server-conf.yml
@@ -7,6 +7,7 @@ directory:
     bucket:
     access_key_id:
     secret_access_key:
+    cache_dir: /home/tatris/data/oss_cache
 segment:
   mature_threshold: 20000
 wal:

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -73,6 +73,8 @@ type OSS struct {
 	Bucket          string `yaml:"bucket"`
 	AccessKeyID     string `yaml:"access_key_id"`
 	SecretAccessKey string `yaml:"secret_access_key"`
+	// CacheDir is the local cache dir for OSS. If it is empty, caching is disabled.
+	CacheDir string `yaml:"cache_dir"`
 }
 
 type Segment struct {

--- a/internal/indexlib/bluge/config/bluge_config.go
+++ b/internal/indexlib/bluge/config/bluge_config.go
@@ -20,8 +20,17 @@ func GetFSConfig(filepath string, filename string) bluge.Config {
 	})
 }
 
-func GetOSSConfig(endpoint, bucket, accessKeyID, secretAccessKey, filename string) bluge.Config {
+func GetOSSConfig(
+	endpoint, bucket, accessKeyID, secretAccessKey, filename, cacheDir string,
+) bluge.Config {
 	return bluge.DefaultConfigWithDirectory(func() index.Directory {
-		return oss.NewOssDirectory(endpoint, bucket, accessKeyID, secretAccessKey, filename)
+		return oss.NewOssDirectory(
+			endpoint,
+			bucket,
+			accessKeyID,
+			secretAccessKey,
+			filename,
+			cacheDir,
+		)
 	})
 }

--- a/internal/indexlib/bluge/directory/oss/directory_oss.go
+++ b/internal/indexlib/bluge/directory/oss/directory_oss.go
@@ -8,10 +8,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
+
+	"github.com/blevesearch/mmap-go"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 
@@ -24,22 +28,30 @@ import (
 	segment "github.com/blugelabs/bluge_segment_api"
 )
 
-type OssDirectory struct {
-	client *oss.Client
-	bucket string
-	index  string
-	lock   sync.RWMutex
-}
+type (
+	OssDirectory struct {
+		client *oss.Client
+		bucket string
+		index  string
+		// cacheDir is the local cache dir for OSS. If it is empty, caching is disabled.
+		cacheDir  string
+		lock      sync.RWMutex
+		bucketObj *oss.Bucket
+	}
+)
 
-func NewOssDirectory(endpoint, bucket, accessKeyID, secretAccessKey, index string) *OssDirectory {
+func NewOssDirectory(
+	endpoint, bucket, accessKeyID, secretAccessKey, index, cacheDir string,
+) *OssDirectory {
 	client, err := NewClient(endpoint, accessKeyID, secretAccessKey)
 	if err != nil {
 		return nil
 	}
 	return &OssDirectory{
-		client: client,
-		bucket: bucket,
-		index:  index,
+		client:   client,
+		bucket:   bucket,
+		index:    index,
+		cacheDir: cacheDir,
 	}
 }
 
@@ -60,6 +72,16 @@ func (d *OssDirectory) Setup(readOnly bool) error {
 			return err
 		}
 	}
+	bucketObj, err := GetBucket(d.client, d.bucket)
+	if err != nil {
+		return err
+	}
+	d.bucketObj = bucketObj
+
+	if d.cacheDir != "" {
+		return os.MkdirAll(d.cacheDir, 0755)
+	}
+
 	return nil
 }
 
@@ -156,6 +178,30 @@ func (d *OssDirectory) Load(kind string, id uint64) (*segment.Data, io.Closer, e
 	defer d.lock.RUnlock()
 
 	key := ossKey(d.index, filename)
+
+	if d.cacheDir != "" {
+		// index may include '/', we replace '/' with '_'
+		// TODO We need to manage the cacheDir directory, such as deleting old files.
+		tempFile, err := os.CreateTemp(
+			d.cacheDir,
+			fmt.Sprintf("%s-%s-%d-*", strings.ReplaceAll(d.index, "/", "_"), kind, id),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		// Close the temp right now, because the file is created with O_EXCL option, which will
+		// cause 'GetObjectToFile' to fail to write.
+		tempFile.Close()
+
+		// Download oss object to file and mmap it.
+		// This can use less memory than keeping the data entirely in memory.
+		if err := d.bucketObj.GetObjectToFile(key, tempFile.Name()); err != nil {
+			os.Remove(tempFile.Name())
+			return nil, nil, err
+		}
+		return mmapFileToSegmentData(tempFile.Name())
+	}
+
 	object, err := GetObject(d.client, d.bucket, key)
 	if err != nil {
 		return nil, nil, err
@@ -176,6 +222,7 @@ func (d *OssDirectory) Load(kind string, id uint64) (*segment.Data, io.Closer, e
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return segment.NewDataBytes(objBytes), nil, nil
 }
 
@@ -263,3 +310,42 @@ type uint64Slice []uint64
 func (e uint64Slice) Len() int           { return len(e) }
 func (e uint64Slice) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
 func (e uint64Slice) Less(i, j int) bool { return e[i] < e[j] }
+
+type closerFunc func() error
+
+func (c closerFunc) Close() error {
+	return c()
+}
+
+func mmapFileToSegmentData(tempPath string) (*segment.Data, io.Closer, error) {
+	file, err := os.Open(tempPath)
+	if err != nil {
+		os.Remove(tempPath)
+		return nil, nil, err
+	}
+	mm, err := mmap.Map(file, mmap.RDONLY, 0)
+	if err != nil {
+		file.Close()
+		os.Remove(tempPath)
+		return nil, nil, err
+	}
+
+	closer := func() error {
+		err1 := mm.Unmap()
+
+		err2 := file.Close()
+
+		err3 := os.Remove(tempPath)
+
+		if err1 == nil {
+			err1 = err2
+		}
+		if err1 == nil {
+			err1 = err3
+		}
+
+		return err1
+	}
+
+	return segment.NewDataBytes(mm), closerFunc(closer), nil
+}

--- a/internal/indexlib/bluge/reader.go
+++ b/internal/indexlib/bluge/reader.go
@@ -83,6 +83,7 @@ func (b *BlugeReader) OpenReader() error {
 				b.Config.OSS.AccessKeyID,
 				b.Config.OSS.SecretAccessKey,
 				segment,
+				b.Config.OSS.CacheDir,
 			)
 		default:
 			cfg = config.GetFSConfig(b.Config.FS.Path, segment)

--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -52,6 +52,8 @@ func (b *BlugeWriter) OpenWriter() error {
 			b.Config.OSS.AccessKeyID,
 			b.Config.OSS.SecretAccessKey,
 			b.Segment,
+			// Using file cache optimization when writing has little effect, so it is not used.
+			"",
 		)
 	default:
 		cfg = config.GetFSConfig(b.Config.FS.Path, b.Segment)

--- a/internal/indexlib/config.go
+++ b/internal/indexlib/config.go
@@ -26,6 +26,7 @@ type ObjectStorageService struct {
 	Bucket          string
 	AccessKeyID     string
 	SecretAccessKey string
+	CacheDir        string
 }
 
 func BuildConf(directory *config.Directory) *Config {
@@ -42,6 +43,7 @@ func BuildConf(directory *config.Directory) *Config {
 			Bucket:          directory.OSS.Bucket,
 			AccessKeyID:     directory.OSS.AccessKeyID,
 			SecretAccessKey: directory.OSS.SecretAccessKey,
+			CacheDir:        directory.OSS.CacheDir,
 		}
 	}
 	return cfg


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
When using OssDirectory, it will load the entire object (bytes) into memory, resulting in a large memory usage.
I added a file system-based cache: Now download the object (bytes) to disk, and then use mmap to load the file. This method is consistent with FileSystemDirectory, so in theory, the read cost of using OssDirectory is compared with FileSystemDirectory, Only the steps of downloading objects (bytes) are added.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
