### PR TITLE
fix: persist the status of the segment

### DIFF
--- a/bin/start-server.sh
+++ b/bin/start-server.sh
@@ -48,4 +48,9 @@ fi
 
 echo "Starting Tatris Server: " $BINARY $BOOTSTRAP_ARGS
 
+# Prints goroutine when panic
+export GOTRACEBACK=all
+# Enable Goalng GC logs
+export GODEBUG=gctrace=1
+
 $BINARY $BOOTSTRAP_ARGS

--- a/internal/core/shard.go
+++ b/internal/core/shard.go
@@ -132,6 +132,11 @@ func (shard *Shard) Close() {
 func (shard *Shard) addSegment(segmentID int) {
 	shard.Segments = append(
 		shard.Segments,
-		&Segment{Shard: shard, SegmentID: segmentID, Stat: Stat{}},
+		&Segment{
+			Shard:         shard,
+			SegmentID:     segmentID,
+			Stat:          Stat{},
+			SegmentStatus: SegmentStatusWritable,
+		},
 	)
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
The 'status' field of Segment is not marshalled by `encoding/json`, so every time tatris restarts, the status it reset to 0. This leads to reopen the underlying writer again when read the segment. So there will always be many open fds.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
