### PR TITLE
feat: obtain OSS resources in segments through HTTP Range requests

### DIFF
--- a/conf/server-conf.yml
+++ b/conf/server-conf.yml
@@ -8,8 +8,9 @@ directory:
     access_key_id:
     secret_access_key:
     cache_dir: /home/tatris/data/oss_cache
+    minimum_concurrency_load_size: 134217728
 segment:
-  mature_threshold: 20000
+  mature_threshold: 300000
 wal:
   no_sync: false
   segment_size: 20971520

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/kong v0.7.1
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.7+incompatible
 	github.com/axw/gocov v1.1.0
+	github.com/blevesearch/mmap-go v1.0.4
 	github.com/blugelabs/bluge v0.2.2
 	github.com/blugelabs/bluge_segment_api v0.2.0
 	github.com/blugelabs/query_string v0.3.0
@@ -29,6 +30,7 @@ require (
 	go.etcd.io/bbolt v1.3.6
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/sync v0.1.0
 	golang.org/x/tools v0.6.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -44,7 +46,6 @@ require (
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f // indirect
 	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
-	github.com/blevesearch/mmap-go v1.0.4 // indirect
 	github.com/blevesearch/segment v0.9.0 // indirect
 	github.com/blevesearch/snowballstem v0.9.0 // indirect
 	github.com/blevesearch/vellum v1.0.7 // indirect
@@ -75,7 +76,7 @@ require (
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.15.2 // indirect
+	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
@@ -108,7 +109,6 @@ require (
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,9 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.15.2 h1:3WH+AG7s2+T8o3nrM/8u2rdqUEcQhmga7smjrT41nAw=
 github.com/klauspost/compress v1.15.2/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
+github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,6 @@
+github.com/blugelabs/bluge v0.1.7/go.mod h1:5d7LktUkQgvbh5Bmi6tPWtvo4+6uRTm6gAwP+5z6FqQ=
+github.com/blugelabs/bluge v0.2.2/go.mod h1:am1LU9jS8dZgWkRzkGLQN3757EgMs3upWrU2fdN9foE=
+github.com/blugelabs/ice v0.2.0/go.mod h1:7foiDf4V83FIYYnGh2LOoRWsbNoCqAAMNgKn879Iyu0=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
@@ -5,4 +8,5 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -75,6 +75,9 @@ type OSS struct {
 	SecretAccessKey string `yaml:"secret_access_key"`
 	// CacheDir is the local cache dir for OSS. If it is empty, caching is disabled.
 	CacheDir string `yaml:"cache_dir"`
+	// MinimumConcurrencyLoadSize is the minimum file size to enable concurrent query.
+	// When the file size to be loaded is greater than this value, oss will be queried concurrently
+	MinimumConcurrencyLoadSize int `yaml:"minimum_concurrency_load_size"`
 }
 
 type Segment struct {

--- a/internal/indexlib/bluge/config/bluge_config.go
+++ b/internal/indexlib/bluge/config/bluge_config.go
@@ -22,6 +22,7 @@ func GetFSConfig(filepath string, filename string) bluge.Config {
 
 func GetOSSConfig(
 	endpoint, bucket, accessKeyID, secretAccessKey, filename, cacheDir string,
+	minimumConcurrencyLoadSize int,
 ) bluge.Config {
 	return bluge.DefaultConfigWithDirectory(func() index.Directory {
 		return oss.NewOssDirectory(
@@ -31,6 +32,7 @@ func GetOSSConfig(
 			secretAccessKey,
 			filename,
 			cacheDir,
+			minimumConcurrencyLoadSize,
 		)
 	})
 }

--- a/internal/indexlib/bluge/directory/oss/directory_oss.go
+++ b/internal/indexlib/bluge/directory/oss/directory_oss.go
@@ -206,24 +206,8 @@ func (d *OssDirectory) Load(kind string, id uint64) (*segment.Data, io.Closer, e
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		err := object.Close()
-		if err != nil {
-			logger.Error(
-				"oss load close object fail",
-				zap.String("index", d.index),
-				zap.String("bucket", d.bucket),
-				zap.String("key", key),
-				zap.Error(err),
-			)
-		}
-	}()
-	objBytes, err := io.ReadAll(object)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	return segment.NewDataBytes(objBytes), nil, nil
+	return segment.NewDataBytes(object), nil, nil
 }
 
 func (d *OssDirectory) Remove(kind string, id uint64) error {

--- a/internal/indexlib/bluge/directory/oss/directory_oss.go
+++ b/internal/indexlib/bluge/directory/oss/directory_oss.go
@@ -37,21 +37,26 @@ type (
 		cacheDir  string
 		lock      sync.RWMutex
 		bucketObj *oss.Bucket
+		// minimumConcurrencyLoadSize is the minimum file size to enable concurrent query.
+		// When the file size to be loaded is greater than this value, oss will be queried concurrently
+		minimumConcurrencyLoadSize int
 	}
 )
 
 func NewOssDirectory(
 	endpoint, bucket, accessKeyID, secretAccessKey, index, cacheDir string,
+	minimumConcurrencyLoadSize int,
 ) *OssDirectory {
 	client, err := NewClient(endpoint, accessKeyID, secretAccessKey)
 	if err != nil {
 		return nil
 	}
 	return &OssDirectory{
-		client:   client,
-		bucket:   bucket,
-		index:    index,
-		cacheDir: cacheDir,
+		client:                     client,
+		bucket:                     bucket,
+		index:                      index,
+		cacheDir:                   cacheDir,
+		minimumConcurrencyLoadSize: minimumConcurrencyLoadSize,
 	}
 }
 
@@ -202,7 +207,7 @@ func (d *OssDirectory) Load(kind string, id uint64) (*segment.Data, io.Closer, e
 		return mmapFileToSegmentData(tempFile.Name())
 	}
 
-	object, err := GetObject(d.client, d.bucket, key)
+	object, err := GetObject(d.client, d.bucket, key, d.minimumConcurrencyLoadSize)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/indexlib/bluge/reader.go
+++ b/internal/indexlib/bluge/reader.go
@@ -84,6 +84,7 @@ func (b *BlugeReader) OpenReader() error {
 				b.Config.OSS.SecretAccessKey,
 				segment,
 				b.Config.OSS.CacheDir,
+				b.Config.OSS.MinimumConcurrencyLoadSize,
 			)
 		default:
 			cfg = config.GetFSConfig(b.Config.FS.Path, segment)

--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -54,6 +54,7 @@ func (b *BlugeWriter) OpenWriter() error {
 			b.Segment,
 			// Using file cache optimization when writing has little effect, so it is not used.
 			"",
+			b.Config.OSS.MinimumConcurrencyLoadSize,
 		)
 	default:
 		cfg = config.GetFSConfig(b.Config.FS.Path, b.Segment)

--- a/internal/indexlib/config.go
+++ b/internal/indexlib/config.go
@@ -22,11 +22,12 @@ type FileSystem struct {
 }
 
 type ObjectStorageService struct {
-	Endpoint        string
-	Bucket          string
-	AccessKeyID     string
-	SecretAccessKey string
-	CacheDir        string
+	Endpoint                   string
+	Bucket                     string
+	AccessKeyID                string
+	SecretAccessKey            string
+	CacheDir                   string
+	MinimumConcurrencyLoadSize int
 }
 
 func BuildConf(directory *config.Directory) *Config {
@@ -39,11 +40,12 @@ func BuildConf(directory *config.Directory) *Config {
 	}
 	if directory.OSS != nil {
 		cfg.OSS = &ObjectStorageService{
-			Endpoint:        directory.OSS.Endpoint,
-			Bucket:          directory.OSS.Bucket,
-			AccessKeyID:     directory.OSS.AccessKeyID,
-			SecretAccessKey: directory.OSS.SecretAccessKey,
-			CacheDir:        directory.OSS.CacheDir,
+			Endpoint:                   directory.OSS.Endpoint,
+			Bucket:                     directory.OSS.Bucket,
+			AccessKeyID:                directory.OSS.AccessKeyID,
+			SecretAccessKey:            directory.OSS.SecretAccessKey,
+			CacheDir:                   directory.OSS.CacheDir,
+			MinimumConcurrencyLoadSize: directory.OSS.MinimumConcurrencyLoadSize,
 		}
 	}
 	return cfg


### PR DESCRIPTION
## Which issue does this PR close?

Closes #225

## Rationale for this change
 - Obtain OSS resources in segments through [HTTP Range](https://help.aliyun.com/document_detail/39571.html) requests
 - Add a configuration `minimum_concurrency_load_size` to control whether to query oss concurrently
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
