### PR TITLE
fix: fix ice initialize docVisitState

### DIFF
--- a/dependencies/ice1/docvalues.go
+++ b/dependencies/ice1/docvalues.go
@@ -276,7 +276,7 @@ func (s *Segment) visitDocumentFieldTerms(localDocNum uint64, fields []string,
 	visitor segment.DocumentValueVisitor, dvs *docVisitState) (
 	*docVisitState, error) {
 	if dvs == nil {
-		dvs = &docVisitState{}
+		dvs = &docVisitState{segment: s}
 	} else if dvs.segment != s {
 		dvs.segment = s
 		dvs.dvrs = nil


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
Fix the initialization problem of `docVisitState` in the ice aggregation process, `docVisitState` uninitialized `segment` causes repeated decompression
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
