### PR TITLE
feat: log mature segments

### DIFF
--- a/internal/core/segment.go
+++ b/internal/core/segment.go
@@ -185,9 +185,9 @@ func (segment *Segment) UpdateStat(min, max time.Time, docs int64) {
 	)
 }
 
-// onMature is called when segment becomes mature.
+// OnMature is called when segment becomes mature.
 // It marks segment readonly and closes the underlying writer.
-func (segment *Segment) onMature() {
+func (segment *Segment) OnMature() {
 	segment.lock.Lock()
 	defer segment.lock.Unlock()
 
@@ -198,11 +198,14 @@ func (segment *Segment) onMature() {
 		segment.closeWriter()
 	}
 
+	segment.Stat.MatureTime = time.Now().UnixMilli()
+
 	logger.Info(
 		"segment is mature",
 		zap.String("segment", segment.GetName()),
 		zap.Int64("docNum", segment.Stat.DocNum),
-		zap.Int64("duration", segment.Stat.MaxTime-segment.Stat.MinTime),
+		zap.Int64("timeRange", segment.Stat.MaxTime-segment.Stat.MinTime),
+		zap.Int64("duration", segment.Stat.MatureTime-segment.Stat.CreateTime),
 	)
 }
 

--- a/internal/core/segment.go
+++ b/internal/core/segment.go
@@ -36,7 +36,7 @@ const (
 type Segment struct {
 	Shard         *Shard `json:"-"`
 	SegmentID     int
-	Stat          Stat
+	Stat          SegmentStat
 	SegmentStatus uint8
 	lock          sync.Mutex
 	writer        indexlib.Writer

--- a/internal/core/segment.go
+++ b/internal/core/segment.go
@@ -197,6 +197,13 @@ func (segment *Segment) onMature() {
 	if reflect.ValueOf(segment.writer).IsValid() && segment.readerRef == 0 {
 		segment.closeWriter()
 	}
+
+	logger.Info(
+		"segment is mature",
+		zap.String("segment", segment.GetName()),
+		zap.Int64("docNum", segment.Stat.DocNum),
+		zap.Int64("duration", segment.Stat.MaxTime-segment.Stat.MinTime),
+	)
 }
 
 func (segment *Segment) closeWriter() {

--- a/internal/core/shard.go
+++ b/internal/core/shard.go
@@ -133,9 +133,13 @@ func (shard *Shard) addSegment(segmentID int) {
 	shard.Segments = append(
 		shard.Segments,
 		&Segment{
-			Shard:         shard,
-			SegmentID:     segmentID,
-			Stat:          Stat{CreateTime: time.Now().UnixMilli()},
+			Shard:     shard,
+			SegmentID: segmentID,
+			Stat: SegmentStat{
+				Stat: Stat{
+					CreateTime: time.Now().UnixMilli(),
+				},
+			},
 			SegmentStatus: SegmentStatusWritable,
 		},
 	)

--- a/internal/core/shard.go
+++ b/internal/core/shard.go
@@ -61,7 +61,7 @@ func (shard *Shard) CheckSegments() {
 			newID := shard.GetSegmentNum()
 			shard.addSegment(newID)
 			if lastedSegment != nil {
-				lastedSegment.onMature()
+				lastedSegment.OnMature()
 			}
 			logger.Info(
 				"add segment",
@@ -82,7 +82,7 @@ func (shard *Shard) ForceAddSegment() {
 	newID := shard.GetSegmentNum()
 	shard.addSegment(newID)
 	if lastedSegment != nil {
-		lastedSegment.onMature()
+		lastedSegment.OnMature()
 	}
 	logger.Info(
 		"add segment",
@@ -135,7 +135,7 @@ func (shard *Shard) addSegment(segmentID int) {
 		&Segment{
 			Shard:         shard,
 			SegmentID:     segmentID,
-			Stat:          Stat{},
+			Stat:          Stat{CreateTime: time.Now().UnixMilli()},
 			SegmentStatus: SegmentStatusWritable,
 		},
 	)

--- a/internal/core/stat.go
+++ b/internal/core/stat.go
@@ -8,11 +8,15 @@ type Stat struct {
 	MinTime    int64
 	MaxTime    int64
 	DocNum     int64
-	MatureTime int64
 }
 
 type ShardStat struct {
 	Stat
 	// WalIndex is the last consumed wal index
 	WalIndex uint64
+}
+
+type SegmentStat struct {
+	Stat
+	MatureTime int64
 }

--- a/internal/core/stat.go
+++ b/internal/core/stat.go
@@ -4,9 +4,11 @@ package core
 
 // Stat records the statistics of an index split
 type Stat struct {
-	MinTime int64
-	MaxTime int64
-	DocNum  int64
+	CreateTime int64
+	MinTime    int64
+	MaxTime    int64
+	DocNum     int64
+	MatureTime int64
 }
 
 type ShardStat struct {

--- a/internal/meta/metadata/index_manager.go
+++ b/internal/meta/metadata/index_manager.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bobg/go-generics/set"
 	"github.com/tatris-io/tatris/internal/common/utils"
@@ -235,7 +236,11 @@ func BuildIndex(index *core.Index, template *protocol.IndexTemplate) {
 		shards[i] = &core.Shard{}
 		shards[i].ShardID = i
 		shards[i].Index = index
-		shards[i].Stat = core.ShardStat{}
+		shards[i].Stat = core.ShardStat{
+			Stat: core.Stat{
+				CreateTime: time.Now().UnixMilli(),
+			},
+		}
 	}
 	index.Shards = shards
 }

--- a/internal/meta/metadata/metadata.go
+++ b/internal/meta/metadata/metadata.go
@@ -121,7 +121,7 @@ func (m *Metadata) initialRevise() error {
 								zap.Uint8("from", segment.SegmentStatus),
 								zap.Uint8("to", core.SegmentStatusReadonly),
 							)
-							segment.SegmentStatus = core.SegmentStatusReadonly
+							segment.OnMature()
 							revised = true
 						}
 					}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
This PR is to log the document number, the time range, and the duration of the segment when it matures naturally.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

1. Add `CreateTime` and `MatureTime` for `SegmentStat`.
2. Add a line of log.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
