### PR TITLE
feat: limit query load

### DIFF
--- a/conf/server-conf.yml
+++ b/conf/server-conf.yml
@@ -23,3 +23,4 @@ query:
   parallel: 10
   default_scan_hours: 72
   default_aggregation_shard_size: 5000
+  max_doc_num: 1000000

--- a/internal/common/errs/error.go
+++ b/internal/common/errs/error.go
@@ -205,3 +205,13 @@ func IsInvalidResourceNameError(err error) bool {
 	var invalidResourceNameErr *InvalidResourceNameError
 	return err != nil && errors.As(err, &invalidResourceNameErr)
 }
+
+type QueryLoadExceedError struct {
+	Indexes []string `json:"indexes"`
+	Message string   `json:"message"`
+	Query   any      `json:"query"`
+}
+
+func (e *QueryLoadExceedError) Error() string {
+	return fmt.Sprintf("query load exceeded: %v, %s: %v", e.Indexes, e.Message, e.Query)
+}

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -43,6 +43,7 @@ func init() {
 			Parallel:                    16,
 			DefaultScanHours:            24 * 3,
 			DefaultAggregationShardSize: 5000,
+			MaxDocNum:                   1000000,
 		},
 	}
 }
@@ -104,6 +105,9 @@ type Query struct {
 	// to better account for these disparate doc counts and improve the accuracy
 	// of the selection of top terms
 	DefaultAggregationShardSize int `yaml:"default_aggregation_shard_size"`
+	// The maximum number of documents that a query is allowed to hit, an errs.QueryLoadExceedError
+	// will be returned if this limit is exceeded.
+	MaxDocNum int64 `yaml:"max_doc_num"`
 }
 
 // Verify wraps doVerify with a `sync.Once`


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
This PR is to protect Tatris when too large a query load comes.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

1. Add a control param `max_doc_num` (default 1000000) to limit the maximum number of documents hit by each query. If the limit is exceeded, an error will be returned directly.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
If a user passes in a query with a heavy load, they may get an error instead of the correct query result.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
