### PR TITLE
feat: add cluster node api

### DIFF
--- a/internal/common/consts/es_version.go
+++ b/internal/common/consts/es_version.go
@@ -1,0 +1,7 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package consts
+
+// ESVersion represents the tatris-compatible elasticsearch version,
+// and some elsticsearch client tools need to obtain the elasticsearch version
+const ESVersion = "7.16.1"

--- a/internal/common/utils/ip_utils.go
+++ b/internal/common/utils/ip_utils.go
@@ -1,0 +1,22 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package utils
+
+import (
+	"net"
+)
+
+func GetLocalIP() (string, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range addrs {
+		if ipNet, ok := addr.(*net.IPNet); ok && !ipNet.IP.IsLoopback() {
+			if ipNet.IP.To4() != nil {
+				return ipNet.IP.String(), err
+			}
+		}
+	}
+	return "", nil
+}

--- a/internal/common/utils/ip_utils_test.go
+++ b/internal/common/utils/ip_utils_test.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Tatris Project Authors. Licensed under Apache-2.0.
+
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetLocalIP(t *testing.T) {
+	ip, err := GetLocalIP()
+	t.Log(ip)
+	assert.Equal(t, err, nil)
+}

--- a/internal/protocol/cluster.go
+++ b/internal/protocol/cluster.go
@@ -19,3 +19,38 @@ type ClusterStatus struct {
 	TaskMaxWaitingInQueueMills  int64   `json:"task_max_waiting_in_queue_millis"`
 	ActiveShardsPercentAsNumber float64 `json:"active_shards_percent_as_number"`
 }
+
+type ClusterInfo struct {
+	Name        string `json:"name"`
+	ClusterName string `json:"cluster_name"`
+	ClusterUUID string `json:"cluster_uuid"`
+	// version represents the elasticsearch version, we cannot modify the structure of
+	// the returned body due to the need to be compatible with the elasticsearch client
+	Version       VersionInfo `json:"version"`
+	TatrisVersion VersionInfo `json:"tatris_version"`
+	Tagline       string      `json:"tagline"`
+}
+
+type ClusterNodesInfo struct {
+	Nodes ClusterNodes `json:"nodes"`
+}
+
+type ClusterNodes map[string]ClusterNode
+
+type ClusterNode struct {
+	Name          string `json:"name"`
+	IP            string `json:"ip"`
+	Host          string `json:"host"`
+	Version       string `json:"version"`
+	TatrisVersion string `json:"tatris_version"`
+}
+
+type VersionInfo struct {
+	Number                    string `json:"number"`
+	BuildFlavor               string `json:"build_flavor"`
+	BuildHash                 string `json:"build_hash"`
+	BuildDate                 string `json:"build_date"`
+	BuildSnapshot             bool   `json:"build_snapshot"`
+	MinimumWireVersion        string `json:"minimum_wire_version"`
+	MinimumIndexCompatibility string `json:"minimum_index_compatibility"`
+}

--- a/internal/service/handler/cluster_handler.go
+++ b/internal/service/handler/cluster_handler.go
@@ -5,7 +5,9 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/tatris-io/tatris/internal/common/consts"
+	"github.com/tatris-io/tatris/internal/common/utils"
 	"github.com/tatris-io/tatris/internal/protocol"
 )
 
@@ -30,4 +32,40 @@ func ClusterStatusHandler(c *gin.Context) {
 		TaskMaxWaitingInQueueMills:  0,
 		ActiveShardsPercentAsNumber: 100,
 	})
+}
+
+func ClusterInfoHandler(c *gin.Context) {
+	id, _ := uuid.NewUUID()
+	OK(c, protocol.ClusterInfo{
+		Name:        "tatris",
+		ClusterName: "docker-cluster",
+		ClusterUUID: id.String(),
+		Version: protocol.VersionInfo{
+			Number: consts.ESVersion,
+		},
+		TatrisVersion: protocol.VersionInfo{
+			Number: consts.Version(),
+		},
+		Tagline: "You Know, for Search",
+	})
+}
+
+func ClusterNodesInfoHandler(c *gin.Context) {
+	id, _ := uuid.NewUUID()
+	ip, err := utils.GetLocalIP()
+	if err != nil {
+		BadRequest(c, err.Error())
+	} else {
+		OK(c, protocol.ClusterNodesInfo{
+			Nodes: protocol.ClusterNodes{
+				id.String(): protocol.ClusterNode{
+					Name:          "tatris",
+					IP:            ip,
+					Host:          ip,
+					Version:       consts.ESVersion,
+					TatrisVersion: consts.Version(),
+				},
+			},
+		})
+	}
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #230

## Rationale for this change
The `Tatris` is compatible with `elasticsearch` clients, and some elasticsearch clients need to obtain cluster information and node information, so tatris needs to implement cluster information and node information related APIs.

## What changes are included in this PR?
- add cluster info api
- add cluster nodes info api
- add response header `X-Elastic-Product=Elasticsearch`  to all APIs, the elasticsearch client validating if the response has X-Elastic-Product=Elasticsearch header
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
