### PR TITLE
fix: set sortable and aggregatable

### DIFF
--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -148,7 +148,6 @@ func (b *BlugeWriter) generateBlugeDoc(
 	bdoc.AddField(bluge.NewStoredOnlyField(consts.SourceField, source))
 	bdoc.AddField(
 		bluge.NewDateTimeField(consts.TimestampField, time.Now()).
-			StoreValue().
 			Sortable().
 			Aggregatable(),
 	)
@@ -220,7 +219,10 @@ func (b *BlugeWriter) addFieldByMappingType(
 			}
 			bfield = bluge.NewDateTimeField(key, date)
 		}
+
+		if lType.Type != consts.LibFieldTypeText {
+			bfield.Sortable().Aggregatable()
+		}
 	}
-	// TODO Sortable、StoreValue、Aggregatable needs to be configured
-	return bfield.Sortable().StoreValue().Aggregatable(), err
+	return bfield, err
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 The written fields only need to be `Sortable` and `Aggregatable` by default
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
