### PR TITLE
feat: stream query

### DIFF
--- a/conf/server-conf.yml
+++ b/conf/server-conf.yml
@@ -22,4 +22,5 @@ query:
   parallel: 10
   default_scan_hours: 72
   default_aggregation_shard_size: 5000
-  max_doc_num: 1000000
+  doc_num_limit: 1000000
+  global_readers_limit: 200

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -43,7 +43,8 @@ func init() {
 			Parallel:                    16,
 			DefaultScanHours:            24 * 3,
 			DefaultAggregationShardSize: 5000,
-			MaxDocNum:                   1000000,
+			DocNumLimit:                 1000000,
+			GlobalReadersLimit:          200,
 		},
 	}
 }
@@ -107,7 +108,10 @@ type Query struct {
 	DefaultAggregationShardSize int `yaml:"default_aggregation_shard_size"`
 	// The maximum number of documents that a query is allowed to hit, an errs.QueryLoadExceedError
 	// will be returned if this limit is exceeded.
-	MaxDocNum int64 `yaml:"max_doc_num"`
+	DocNumLimit int64 `yaml:"doc_num_limit"`
+	// The maximum number of readers allowed to load data at the same time, which is a threshold
+	// used to limit the global instantaneous resource usage.
+	GlobalReadersLimit int `yaml:"global_readers_limit"`
 }
 
 // Verify wraps doVerify with a `sync.Once`

--- a/internal/indexlib/bluge/analyzer.go
+++ b/internal/indexlib/bluge/analyzer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/blugelabs/bluge/analysis/analyzer"
 )
 
-func generateAnalyzer(analyzerStr string) *analysis.Analyzer {
+func genAnalyzer(analyzerStr string) *analysis.Analyzer {
 	switch strings.ToUpper(analyzerStr) {
 	case "KEYWORD":
 		return analyzer.NewKeywordAnalyzer()

--- a/internal/indexlib/bluge/doc_heap.go
+++ b/internal/indexlib/bluge/doc_heap.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Tatris Project Authors. Licensed under Apache-2.0.
+
+package bluge
+
+import "github.com/blugelabs/bluge/search"
+
+// An DocHeap is a min-heap of search.DocumentMatch.
+type DocHeap struct {
+	docs []*search.DocumentMatch
+	sort search.SortOrder
+}
+
+func (h *DocHeap) Len() int           { return len(h.docs) }
+func (h *DocHeap) Less(i, j int) bool { return h.sort.Compare(h.docs[i], h.docs[j]) < 0 }
+func (h *DocHeap) Swap(i, j int)      { h.docs[i], h.docs[j] = h.docs[j], h.docs[i] }
+
+func (h *DocHeap) Push(x any) {
+	h.docs = append(h.docs, x.(*search.DocumentMatch))
+}
+
+func (h *DocHeap) Pop() any {
+	old := *h
+	n := len(old.docs)
+	x := old.docs[n-1]
+	h.docs = old.docs[0 : n-1]
+	return x
+}

--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -201,7 +201,7 @@ func (b *BlugeWriter) addFieldByMappingType(
 				return nil, &errs.InvalidFieldValError{Field: key, Type: mappingType, Value: value}
 			}
 			bfield = bluge.NewKeywordField(key, keywordValue)
-			bfield.WithAnalyzer(generateAnalyzer("keyword"))
+			bfield.WithAnalyzer(genAnalyzer("keyword"))
 		case consts.LibFieldTypeBool:
 			boolValue, ok := value.(bool)
 			if !ok {
@@ -215,7 +215,7 @@ func (b *BlugeWriter) addFieldByMappingType(
 			}
 			bfield = bluge.NewTextField(key, textValue)
 			// TODO get analyzer from config
-			bfield.WithAnalyzer(generateAnalyzer(""))
+			bfield.WithAnalyzer(genAnalyzer(""))
 		case consts.LibFieldTypeDate:
 			var date time.Time
 			date, err := utils.ParseTime(value)

--- a/internal/query/query_doc.go
+++ b/internal/query/query_doc.go
@@ -57,7 +57,7 @@ func SearchDocs(
 	for _, segment := range allSegments {
 		docNum += segment.Stat.DocNum
 	}
-	var docNumLimit = config.Cfg.Query.MaxDocNum
+	var docNumLimit = config.Cfg.Query.DocNumLimit
 	if docNum > docNumLimit {
 		return nil, &errs.QueryLoadExceedError{
 			Indexes: indexNames,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #248 

## Rationale for this change
This PR is to protect the system during a large query load influx.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Add a control parameter `global_readers_limit` to limit the number of readers that are loading data globally.
- The query is implemented by multiple goroutines interacting through channels.
- Document collation is implemented by heap sorting.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Users will get a more stable query experience.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regression tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
