### PR TITLE
feat: optimize reader initialization

### DIFF
--- a/conf/server-conf.yml
+++ b/conf/server-conf.yml
@@ -20,7 +20,7 @@ wal:
   file_perms: 0640
 query:
   parallel: 10
-  default_scan_hours: 72
+  default_scan_hours: 12
   default_aggregation_shard_size: 5000
   doc_num_limit: 1000000
   global_readers_limit: 200

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -40,8 +40,7 @@ func init() {
 			Parallel:         16,
 		},
 		Query: &Query{
-			Parallel:                    16,
-			DefaultScanHours:            24 * 3,
+			DefaultScanHours:            12,
 			DefaultAggregationShardSize: 5000,
 			DocNumLimit:                 1000000,
 			GlobalReadersLimit:          200,
@@ -98,8 +97,6 @@ type Wal struct {
 }
 
 type Query struct {
-	// the number of Goroutines used to retrieve multiple segments per query
-	Parallel int `yaml:"parallel"`
 	// the default number of hours to scan when no time range is explicitly passed in
 	DefaultScanHours int `yaml:"default_scan_hours"`
 	// acts on terms aggregation, increase default_aggregation_shard_size
@@ -184,9 +181,6 @@ func (w *Wal) verify() {
 }
 
 func (q *Query) verify() {
-	if q.Parallel <= 0 {
-		panic("query.parallel should be positive")
-	}
 }
 
 // doVerify verifies the control parameters of all modules

--- a/internal/indexlib/bluge/writer.go
+++ b/internal/indexlib/bluge/writer.go
@@ -99,11 +99,7 @@ func (b *BlugeWriter) Reader() (indexlib.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &BlugeReader{
-		Config:   b.Config,
-		Segments: []string{b.Segment},
-		Readers:  []*bluge.Reader{reader},
-	}, nil
+	return NewBlugeReader(b.Config, []string{b.Segment}, []*bluge.Reader{reader}, nil), nil
 }
 
 func (b *BlugeWriter) Close() {

--- a/internal/indexlib/manage/manage.go
+++ b/internal/indexlib/manage/manage.go
@@ -33,7 +33,7 @@ func GetReader(
 	// var here) of the index may have different mappings
 	switch config.IndexLib {
 	case consts.IndexLibBluge:
-		blugeReader := bluge.NewBlugeReader(config, segments...)
+		blugeReader := bluge.NewBlugeReader(config, segments, nil, nil)
 		err := blugeReader.OpenReader()
 		if err != nil {
 			logger.Error("bluge open reader failed", zap.Error(err))


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
This PR is to optimize the reader initialization and unify some control parameters.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

1. Treat `NewBlugeReader` as the only entry for reader initialization.
2. Remove the control parameter `Query.Parallel`, each reader will start a goroutine instead.
3. Modified the value of some control parameters.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
