### PR TITLE
fix: fix query size zero value

### DIFF
--- a/internal/protocol/marshal.go
+++ b/internal/protocol/marshal.go
@@ -66,7 +66,7 @@ func (q *QueryRequest) UnmarshalJSON(data []byte) error {
 	if !reflect.ValueOf(tmp.Sort).IsZero() {
 		q.Sort = tmp.Sort
 	}
-	if !reflect.ValueOf(tmp.Size).IsZero() {
+	if reflect.ValueOf(tmp.Size).Int() >= 0 {
 		q.Size = tmp.Size
 	}
 	if !reflect.ValueOf(tmp.From).IsZero() {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
Fix the problem that the query size is zero and does not take effect.
Tatris should allow the query size to pass in a zero value, and the queried hits are empty.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
