### PR TITLE
feat: rename time series field from _timestamp to @timestamp

### DIFF
--- a/internal/common/consts/fields.go
+++ b/internal/common/consts/fields.go
@@ -4,7 +4,7 @@
 package consts
 
 const (
-	TimestampField = "_timestamp"
+	TimestampField = "@timestamp"
 	IDField        = "_id"
 	SourceField    = "_source"
 	IndexField     = "_index"

--- a/internal/indexlib/query_response.go
+++ b/internal/indexlib/query_response.go
@@ -29,7 +29,7 @@ type Hit struct {
 	Index     string            `json:"_index"`
 	ID        string            `json:"_id"`
 	Source    protocol.Document `json:"_source"`
-	Timestamp time.Time         `json:"_timestamp"`
+	Timestamp time.Time         `json:"@timestamp"`
 	Score     float64           `json:"_score"`
 	Type      string            `json:"_type"`
 }

--- a/internal/query/query_doc.go
+++ b/internal/query/query_doc.go
@@ -176,7 +176,12 @@ func resolveTimeRange(index string, query protocol.Query) (int64, int64, error) 
 		end = now
 	}
 	if start == 0 || start > end {
-		start = end - (time.Hour.Milliseconds() * int64(config.Cfg.Query.DefaultScanHours))
+		start = int64(
+			math.Max(
+				0,
+				float64(end-(time.Hour.Milliseconds()*int64(config.Cfg.Query.DefaultScanHours))),
+			),
+		)
 	}
 	logger.Info(
 		"unable to resolve time range from request, set to default",


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
This PR is to rename the default time series field from `_timestamp` to `@timestamp` to be compatible with current mainstream log collection components (such as `logstash`) and their protocols.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

1. Rename the time series field from `_timestamp` to `@timestamp`.
2. Verify that the default query time range is non-negative.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
This is an incompatible change, and users need to rebuild the index.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
CI and regress tests passed.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
